### PR TITLE
refactor: convert cache to JSONL and remove paper_cite field

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-cache/cache.json filter=lfs diff=lfs merge=lfs -text
+cache/cache.jsonl filter=lfs diff=lfs merge=lfs -text

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ PaperVault/
 ├── update_cache.py           # CLI tool to add conferences from GitHub issues
 ├── requirements.txt          # Python dependencies
 ├── cache/
-│   └── cache.json            # Local JSON database of all papers
+│   └── cache.jsonl           # Local JSON database of all papers (JSON Lines)
 ├── conf/                     # Conference source configurations
 │   ├── acl_conf.json         # ACL Anthology sources (NLP)
 │   ├── dblp_conf.json        # DBLP sources (mixed venues)
@@ -92,7 +92,7 @@ The Flask server runs on `http://127.0.0.1:5000` by default.
 
 ### Git LFS
 
-The paper cache file (`cache/cache.json`) is managed by [Git LFS](https://git-lfs.github.com) due to its large size. Make sure you have Git LFS installed before cloning:
+The paper cache file (`cache/cache.jsonl`) is managed by [Git LFS](https://git-lfs.github.com) due to its large size. Make sure you have Git LFS installed before cloning:
 
 ```bash
 # Install Git LFS (one-time setup)
@@ -139,7 +139,7 @@ This builds the frontend into the `static/` directory at the project root, which
 | Command | Description |
 |---------|-------------|
 | `python app.py` | Start Flask backend server |
-| `python collector.py` | Run collector to update `cache/cache.json` |
+| `python collector.py` | Run collector to update `cache/cache.jsonl` |
 | `python maintain.py` | Update README conference list from config files |
 | `python maintain.py force` | Force full cache rebuild and README update |
 | `python update_cache.py --issue "..."` | Parse issue body and add new conferences |

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -6,10 +6,10 @@ PaperVault 采用**前后端分离**架构：
 
 - **后端**：Python Flask 提供 REST API，启动时加载本地 JSON 缓存，所有检索均在内存中完成，不依赖数据库。
 - **前端**：Vue 3 + Vite + TypeScript 构建的单页应用（SPA），打包后输出为静态文件，由 Flask 直接托管。
-- **数据层**：`cache/cache.json` 为单一本地缓存文件，使用 **Git LFS** 管理；`conf/*.json` 定义需要采集的会议列表。
+- **数据层**：`cache/cache.jsonl` 为单一本地缓存文件（JSON Lines 格式），使用 **Git LFS** 管理；`conf/*.json` 定义需要采集的会议列表。
 
 ```
-conf/*.json  ──►  collector.py  ──►  cache/cache.json
+conf/*.json  ──►  collector.py  ──►  cache/cache.jsonl
                                          ▲
                                          │
                                     app.py (Flask)
@@ -70,7 +70,7 @@ conf/*.json  ──►  collector.py  ──►  cache/cache.json
 
 ### 2.3 缓存加载机制
 
-`app.py` 在模块导入时即执行 `load_data()`，将 `cache/cache.json` 全部读入内存，按会议和年份组织为嵌套字典 `cache_data`。此后所有搜索均在内存中进行，无磁盘 I/O。
+`app.py` 在模块导入时即执行 `load_data()`，将 `cache/cache.jsonl` 流式读入内存，按会议和年份组织为嵌套字典 `cache_data`。此后所有搜索均在内存中进行，无磁盘 I/O。
 
 ---
 
@@ -167,24 +167,17 @@ cache_conf = [name for name in cache_res.keys()]
 | `url` | 是 | 该会议在对应数据源的列表页 URL |
 | `tag` | 部分需要 | ACL Anthology 等需要额外路径标识，DBLP/OpenReview 等不需要 |
 
-### 5.2 缓存格式 (`cache/cache.json`)
+### 5.2 缓存格式 (`cache/cache.jsonl`)
 
-```json
-{
-    "ACL2023": [
-        {
-            "paper_name": "Paper Title",
-            "paper_url": "https://...",
-            "paper_authors": ["Author A", "Author B"],
-            "paper_abstract": "Abstract text...",
-            "paper_code": "https://github.com/...",
-            "paper_cite": -1
-        }
-    ]
-}
+每行为一篇论文的 JSON 对象，额外包含 `conf` 字段标识所属会议：
+
+```jsonl
+{"conf": "ACL2023", "paper_name": "Paper Title", "paper_url": "https://...", "paper_authors": ["Author A", "Author B"], "paper_abstract": "Abstract text...", "paper_code": "https://github.com/..."}
+{"conf": "ACL2023", "paper_name": "Another Title", ...}
+{"conf": "CVPR2023", "paper_name": "...", ...}
 ```
 
-顶层键为 `"会议名+年份"`，值为该会议当年的论文列表。`paper_code` 默认值为 `#`，表示暂无代码链接；`paper_cite` 默认值为 `-1`，表示未获取引用数。
+`paper_code` 默认值为 `#`，表示暂无代码链接。
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ app.config['BOOTSTRAP_SERVE_LOCAL'] = True
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 
-cache_json = os.path.join(base_dir, "cache", "cache.jsonl")
+cache_path = os.path.join(base_dir, "cache", "cache.jsonl")
 
 cache_data = {}
 support_confs = []
@@ -47,7 +47,7 @@ def add_item(item: dict):
 
 
 def load_data():
-    data = load_cache(cache_json)
+    data = load_cache(cache_path)
 
     for conf in data:
         year = re.search(r"\d{4}", conf).group()

--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import re
 import time
 import asyncio
 import openai
+from collector import load_cache
 from EdgeGPT import Chatbot as ChatbotEdge
 from revChatGPT.Official import Chatbot as ChatbotOfficial
 
@@ -22,7 +23,7 @@ app.config['BOOTSTRAP_SERVE_LOCAL'] = True
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 
-cache_json = os.path.join(base_dir, "cache", "cache.json")
+cache_json = os.path.join(base_dir, "cache", "cache.jsonl")
 
 cache_data = {}
 support_confs = []
@@ -41,14 +42,12 @@ def add_item(item: dict):
             "authors": item["authors"],
             "abstract": item["abstract"],
             "code": item["code"],
-            "citation": item["citation"],
         }
     )
 
 
 def load_data():
-    with open(cache_json, "r") as f:
-        data = json.load(f)
+    data = load_cache(cache_json)
 
     for conf in data:
         year = re.search(r"\d{4}", conf).group()
@@ -68,7 +67,6 @@ def load_data():
                     "authors": paper["paper_authors"],
                     "abstract": paper["paper_abstract"],
                     "code": paper["paper_code"],
-                    "citation": paper["paper_cite"],
                 }
             )
 
@@ -116,7 +114,6 @@ def search(query, confs, year, sp_year=None, sp_author=None, limit=None):
                         "authors": paper["authors"],
                         "abstract": paper["abstract"],
                         "code": paper["code"],
-                        "citation": paper["citation"],
                     })
                     result_count += 1
                     if limit is not None and result_count >= limit:
@@ -130,7 +127,6 @@ def search(query, confs, year, sp_year=None, sp_author=None, limit=None):
                         "authors": paper["authors"],
                         "abstract": paper["abstract"],
                         "code": paper["code"],
-                        "citation": paper["citation"],
                     })
                     result_count += 1
                     if limit is not None and result_count >= limit:
@@ -144,7 +140,6 @@ def search(query, confs, year, sp_year=None, sp_author=None, limit=None):
                         "authors": paper["authors"],
                         "abstract": paper["abstract"],
                         "code": paper["code"],
-                        "citation": paper["citation"],
                     })
                     result_count += 1
                     if limit is not None and result_count >= limit:

--- a/cache/cache.json
+++ b/cache/cache.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bb9430b8ae491c668d4f1f1c95c2145cd4ef54e17e6724ab243c7be4e0f2df68
-size 66296361

--- a/cache/cache.jsonl
+++ b/cache/cache.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7603eb1a2e33366233fb21c58f132d068cdc9fc9479883ae6a6d7a919be98ca4
+size 66499827

--- a/collector.py
+++ b/collector.py
@@ -24,7 +24,6 @@ def search_from_iclr(url, name, res):
                 "paper_authors": item["content"]["authors"],
                 "paper_abstract": item['content']['abstract'],
                 "paper_code": "#",
-                "paper_cite": -1,
             }
         )
     return res
@@ -62,7 +61,6 @@ def search_from_nips(url, name, res):
                 "paper_authors": paper_author,
                 "paper_abstract": paper_abstract,
                 "paper_code": "#",
-                "paper_cite": -1,
             }
         )
     return res
@@ -93,7 +91,6 @@ def search_from_acl(url, tag, name, res):
                     "paper_authors": [author.string for author in tp.find_all('a', href=re.compile("people/"))],
                     "paper_abstract": paper_abstract,
                     "paper_code": "#",
-                    "paper_cite": -1,
                 }
             )
     return res
@@ -176,7 +173,6 @@ def search_from_dblp(url, name, res):
                 "paper_authors": paper_authors,
                 "paper_abstract": paper_abstract,
                 "paper_code": "#",
-                "paper_cite": -1,
             }
         )
     return res
@@ -213,7 +209,6 @@ def search_from_thecvf(url, name, res):
                 "paper_authors": paper_authors,
                 "paper_abstract": paper_abstract,
                 "paper_code": "#",
-                "paper_cite": -1,
             }
         )
     return res
@@ -265,31 +260,6 @@ def add_code_links(res):
                 import pdb; pdb.set_trace();
     return res
 
-def get_citation(keyword):
-    url = f'https://api.semanticscholar.org/graph/v1/paper/search?query={keyword}&limit=1&fields=title,citationCount'
-    r = requests.get(url, headers=HEADERS)
-    data = r.json()
-    if 'data' in data and len(data['data']):
-        citation = data['data'][0]['citationCount']
-        title = data['data'][0]['title']
-    else:
-        citation = 0
-    time.sleep(3)
-    return citation
-
-def add_citation(res):
-    for conf in res:
-        for ii, item in enumerate(tqdm(res[conf], desc="[+] Collecting Citations", dynamic_ncols=True)):
-            paper_name = item['paper_name']
-            paper_citation = item["paper_cite"]
-            if paper_citation != -1:
-                continue
-            if paper_name.endswith('.'):
-                paper_name = paper_name[:-1]
-            citation = get_citation(paper_name)
-            res[conf][ii]['paper_cite'] = citation
-    return res
-
 def collect(cache_file=None, force=False):
     res = {}
 
@@ -303,7 +273,7 @@ def collect(cache_file=None, force=False):
     cache_res = {}
     if not force and cache_file is not None and os.path.exists(cache_file):
         # incremental update
-        cache_res = json.load(open(cache_file, "r"))
+        cache_res = load_cache(cache_file)
         cache_conf = [name for name in cache_res.keys()]
 
     for conf in tqdm(acl_conf, desc="[+] Collecting ACL", dynamic_ncols=True):
@@ -345,23 +315,46 @@ def collect(cache_file=None, force=False):
     res.update(cache_res)
 
     res = add_code_links(res)
-    # res = add_citation(res) # hard to get citations
 
     return res
+
+
+def load_cache(path):
+    """读取 JSONL，重组为 dict[conf_name] -> list[paper_dict]"""
+    data = {}
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            paper = json.loads(line)
+            conf = paper.pop("conf")
+            if conf not in data:
+                data[conf] = []
+            data[conf].append(paper)
+    return data
+
+
+def save_cache(path, data):
+    """将 dict[conf_name] -> list[paper_dict] 写入 JSONL"""
+    with open(path, "w", encoding="utf-8") as f:
+        for conf, papers in data.items():
+            for paper in papers:
+                record = dict(paper)
+                record["conf"] = conf
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
 
 
 def do_collect(cache_file=None, force=False):
     if force or cache_file is None or not os.path.exists(cache_file):
         print(f"[+] Collecting papers...")
         res = collect(cache_file)
-        with open(cache_file, "w") as f:
-            json.dump(res, f)
+        save_cache(cache_file, res)
     else:
         print(f"[+] Loading from cache...")
-        with open(cache_file, "r") as f:
-            res = json.load(f)
+        res = load_cache(cache_file)
     return res
 
 
 if __name__ == "__main__":
-    do_collect(cache_file="cache/cache.json", force=True)
+    do_collect(cache_file="cache/cache.jsonl", force=True)

--- a/collector.py
+++ b/collector.py
@@ -257,7 +257,7 @@ def add_code_links(res):
                     res[conf][ii]['paper_code'] = link
                     break
             if not flag:
-                import pdb; pdb.set_trace();
+                print(f"[!] Warning: no matching paper found in cache for code-link title: {title!r} (conf={conf})")
     return res
 
 def collect(cache_file=None, force=False):
@@ -323,11 +323,18 @@ def load_cache(path):
     """读取 JSONL，重组为 dict[conf_name] -> list[paper_dict]"""
     data = {}
     with open(path, "r", encoding="utf-8") as f:
-        for line in f:
+        for line_num, line in enumerate(f, start=1):
             line = line.strip()
             if not line:
                 continue
-            paper = json.loads(line)
+            try:
+                paper = json.loads(line)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Malformed JSON on line {line_num} of {path}: {e}")
+            if "conf" not in paper or not isinstance(paper["conf"], str):
+                raise ValueError(
+                    f"Missing or invalid 'conf' field on line {line_num} of {path}"
+                )
             conf = paper.pop("conf")
             if conf not in data:
                 data[conf] = []
@@ -348,7 +355,7 @@ def save_cache(path, data):
 def do_collect(cache_file=None, force=False):
     if force or cache_file is None or not os.path.exists(cache_file):
         print(f"[+] Collecting papers...")
-        res = collect(cache_file)
+        res = collect(cache_file, force=force)
         save_cache(cache_file, res)
     else:
         print(f"[+] Loading from cache...")

--- a/maintain.py
+++ b/maintain.py
@@ -2,12 +2,12 @@ import os
 import sys
 import json
 import re
-from collector import collect
+from collector import collect, save_cache
 
 COMMENT_CONFS_LIST_START = "<!-- confs-list-start -->"
 COMMENT_CONFS_LIST_END = "<!-- confs-list-end -->"
 
-cache_path = os.path.join(os.path.dirname(__file__), "cache", "cache.json")
+cache_path = os.path.join(os.path.dirname(__file__), "cache", "cache.jsonl")
 readme_path = "README.md"
 acl_conf_path = os.path.join(os.path.dirname(__file__), "conf", "acl_conf.json")
 dblp_conf_path = os.path.join(os.path.dirname(__file__), "conf", "dblp_conf.json")
@@ -71,8 +71,7 @@ def update_readme():
 
 def force_update():
     res = collect(cache_file=None, force=True)
-    with open(cache_path, "w") as f:
-        json.dump(res, f)
+    save_cache(cache_path, res)
 
 
 if __name__ == "__main__":

--- a/update_cache.py
+++ b/update_cache.py
@@ -61,7 +61,7 @@ def add_list(args):
 def main():
     args = set_args()
     add_list(args)
-    do_collect(cache_file="cache/cache.json", force=True)
+    do_collect(cache_file="cache/cache.jsonl", force=True)
 
 
 if __name__ == "__main__":

--- a/web-vue/src/components/SearchResultList.vue
+++ b/web-vue/src/components/SearchResultList.vue
@@ -18,7 +18,7 @@ let resultList: any = reactive({
   val: []
 })
 
-let sortMethod = ref('Hot')
+let sortMethod = ref('Year')
 
 const exportFile = (method: string): void => {
   if (method === 'csv') {
@@ -68,11 +68,7 @@ const getAllResult = (target: any): void => {
 }
 
 const changeSortMethod = (method: any): void => {
-  if (method === 'Hot') {
-    resultList.val = resultList.val.sort(
-      (a: any, b: any) => b.citation - a.citation
-    )
-  } else if (method === 'Year') {
+  if (method === 'Year') {
     resultList.val = resultList.val.sort(
       (a: any, b: any) => Number(b.year) - Number(a.year)
     )
@@ -144,7 +140,6 @@ defineExpose({
     >
       <span style="padding-right: 10px">Sort By:</span>
       <el-radio-group v-model="sortMethod" @change="changeSortMethod">
-        <el-radio label="Hot" />
         <el-radio label="Year" />
         <el-radio label="Conf" />
       </el-radio-group>

--- a/web-vue/src/components/SearchResultList.vue
+++ b/web-vue/src/components/SearchResultList.vue
@@ -29,7 +29,8 @@ const exportFile = (method: string): void => {
 }
 
 const deleteResult = (index: number): void => {
-  resultList.val.splice(index, 1)
+  const absoluteIndex = (page.current - 1) * page.size + index
+  resultList.val.splice(absoluteIndex, 1)
 }
 
 const jumpUrl = (url: string) => {
@@ -48,18 +49,16 @@ const filterResult: (target: any, option: any) => void = (target, option) => {
   } else if (Number(level) === 2) {
     for (let k in target[key]) {
       resultList.val = resultList.val.concat(target[key][k])
-      changeSortMethod(sortMethod.value)
     }
-  } else if (Number(level === 3)) {
+  } else if (Number(level) === 3) {
     resultList.val = resultList.val.concat(target[parent][key])
-    changeSortMethod(sortMethod.value)
   }
+  changeSortMethod(sortMethod.value)
 }
 
 const getAllResult = (target: any): void => {
   if (Array.isArray(target)) {
     resultList.val = resultList.val.concat(target as never)
-    changeSortMethod(sortMethod.value)
   } else {
     for (let k in target) {
       getAllResult(target[k])
@@ -73,7 +72,6 @@ const changeSortMethod = (method: any): void => {
       (a: any, b: any) => Number(b.year) - Number(a.year)
     )
   } else if (method === 'Conf') {
-    console.log(11)
     resultList.val = resultList.val.sort((a: any, b: any) => {
       let a1 = a.conf.toUpperCase()
       let b1 = b.conf.toUpperCase()

--- a/web-vue/src/utils/file.ts
+++ b/web-vue/src/utils/file.ts
@@ -17,7 +17,6 @@ export default {
       'authors',
       'abstract',
       'code',
-      'citation',
       'conf',
       'year'
     ]

--- a/web-vue/src/utils/file.ts
+++ b/web-vue/src/utils/file.ts
@@ -29,7 +29,7 @@ export default {
         if (v[key] instanceof Array) {
           row += `"${v[key].join(',')}\t",`
         } else {
-          row += `"${String(v[key]).replaceAll('"', '"')}\t",`
+          row += `"${String(v[key]).replaceAll('"', '""')}\t",`
         }
       })
       row = row.substring(0, row.length - 1) + '\n'
@@ -49,7 +49,7 @@ export default {
     jsonData.forEach((v: any) => {
       text += `[${v.conf + v.year}]\t${v.title}\r\n`
     })
-    const uri = 'data:text/csv;charset=utf-8,' + encodeURIComponent(text)
+    const uri = 'data:text/plain;charset=utf-8,' + encodeURIComponent(text)
     const link = document.createElement('a')
     link.setAttribute('href', uri)
     link.setAttribute('download', fileName)


### PR DESCRIPTION
- Convert cache/cache.json (64MB single-line) to cache/cache.jsonl (94,641 lines, one paper per line)
- Add load_cache() / save_cache() utilities in collector.py for JSONL I/O
- Update app.py, maintain.py, collector.py to use new cache path and functions
- Remove paper_cite initialization and add_citation()/get_citation() functions from collector.py
- Remove citation field from API responses in app.py
- Remove 'Hot' sort option (by citation) from frontend; default sort changed to 'Year'
- Remove citation column from CSV export
- Update .gitattributes, AGENTS.md, TECHNICAL.md for new cache.jsonl format