### PR TITLE
docs: add project status notice to README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -10,6 +10,22 @@
 
 Fully-automated scripts for collecting AI-related papers.
 
+## 🚧 Project Status
+
+> **This project is actively under construction.**
+
+### Current Phase
+- Expanding the paper coverage, with a focus on high-quality **journals and publishers from 2020 onward** (e.g., TIP, TPAMI, TKDE, TNNLS, TASLP, IJCV, etc.).
+- Backfilling **abstracts** for existing papers via automated scripts and GitHub Actions to enhance searchability.
+- The database currently contains **94,000+** papers spanning 40+ top-tier conferences and journals across NLP, CV, ML, DM, DB, and Speech.
+
+### Next Steps
+- Upgrade the frontend and backend stack for a better search experience and UI.
+- Redeploy and relaunch the web search service.
+
+### Project History
+PaperVault was originally forked from [MLNLP-World/AI-Paper-Collector](https://github.com/MLNLP-World/AI-Paper-Collector) and is now developed independently. We are evolving it from a static paper list into a fully-featured, data-rich online academic search engine.
+
 ## :open_book: Search Categories
 
 <!-- confs-list-start -->

--- a/README.en.md
+++ b/README.en.md
@@ -17,7 +17,7 @@ Fully-automated scripts for collecting AI-related papers.
 ### Current Phase
 - Expanding paper coverage from 2020 onward, especially high-quality **journals** (e.g., TIP, TPAMI, TKDE, TNNLS, TASLP, IJCV, etc.) and major **publishers** (e.g., IEEE, ACM, Springer, Elsevier).
 - Backfilling **abstracts** for existing papers via automated scripts and GitHub Actions to enhance searchability.
-- The database currently contains **94,000+** papers spanning 40+ top-tier conferences and journals across NLP, CV, ML, DM, DB, and Speech.
+- The database contains **94,000+** papers spanning 40+ top-tier conferences and journals across NLP, CV, ML, DM, DB, and Speech.
 
 ### Next Steps
 - Upgrade the frontend and backend stack for a better search experience and UI.

--- a/README.en.md
+++ b/README.en.md
@@ -24,7 +24,7 @@ Fully-automated scripts for collecting AI-related papers.
 - Redeploy and relaunch the web search service.
 
 ### Project History
-PaperVault was originally forked from [MLNLP-World/AI-Paper-Collector](https://github.com/MLNLP-World/AI-Paper-Collector) and is now developed independently. We are evolving it from a static paper list into a fully-featured, data-rich online academic search engine.
+PaperVault is evolving it from a static paper list into a fully-featured, data-rich online academic search engine (see Acknowledgements below for project origin).
 
 ## :open_book: Search Categories
 

--- a/README.en.md
+++ b/README.en.md
@@ -15,7 +15,7 @@ Fully-automated scripts for collecting AI-related papers.
 > **This project is actively under construction.**
 
 ### Current Phase
-- Expanding the paper coverage, with a focus on high-quality **journals and publishers from 2020 onward** (e.g., TIP, TPAMI, TKDE, TNNLS, TASLP, IJCV, etc.).
+- Expanding paper coverage from 2020 onward, especially high-quality **journals** (e.g., TIP, TPAMI, TKDE, TNNLS, TASLP, IJCV, etc.) and major **publishers** (e.g., IEEE, ACM, Springer, Elsevier).
 - Backfilling **abstracts** for existing papers via automated scripts and GitHub Actions to enhance searchability.
 - The database currently contains **94,000+** papers spanning 40+ top-tier conferences and journals across NLP, CV, ML, DM, DB, and Speech.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ PaperVault 是一个用于收集和检索人工智能领域学术论文的全自
 - 重新部署并上线 Web 搜索服务，支持更高效的论文检索与浏览。
 
 ### 项目历程
-PaperVault 最初 fork 自 [MLNLP-World/AI-Paper-Collector](https://github.com/MLNLP-World/AI-Paper-Collector)，现已作为独立项目持续发展。我们正在将其从一个静态论文清单工具，逐步建设为一个功能完善、数据丰富的在线学术搜索引擎。
+PaperVault 由 [MLNLP-World/AI-Paper-Collector](https://github.com/MLNLP-World/AI-Paper-Collector) 演进而来（fork 来源详见下方致谢），正在将其从一个静态论文清单工具逐步建设为一个功能完善、数据丰富的在线学术搜索引擎。
 
 ## :open_book: 收录会议范围
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ PaperVault 是一个用于收集和检索人工智能领域学术论文的全自
 ### 当前阶段
 - 正在大幅扩展论文收录范围，重点补充 **2020 年至今** 的更多优质期刊（如 TIP、TPAMI、TKDE、TNNLS、TASLP、IJCV 等）以及主流出版社（如 IEEE、ACM、Springer、Elsevier 等）的论文清单。
 - 已通过自动化脚本和 GitHub Actions 批量为论文填充 **摘要（abstract）** 信息，提升检索价值。
-- 当前数据库已收录 **94,000+** 篇论文，覆盖 NLP、CV、ML、DM、DB、Speech 等 40+ 个顶级会议与期刊。
+- 数据库已收录 **94,000+** 篇论文，覆盖 NLP、CV、ML、DM、DB、Speech 等 40+ 个顶级会议与期刊。
 
 ### 下阶段目标
 - 升级前后端技术栈，优化搜索体验与界面设计。

--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@
 
 PaperVault 是一个用于收集和检索人工智能领域学术论文的全自动化工具，覆盖 NLP、CV、ML、DM、DB 和语音等多个方向的顶级学术会议。
 
+## 🚧 项目状态
+
+> **本项目仍在积极施工中。**
+
+### 当前阶段
+- 正在大幅扩展论文收录范围，重点补充 **2020 年至今** 的更多优质期刊（如 TIP、TPAMI、TKDE、TNNLS、TASLP、IJCV 等）和出版社论文清单。
+- 已通过自动化脚本和 GitHub Actions 批量为论文填充 **摘要（abstract）** 信息，提升检索价值。
+- 当前数据库已收录 **94,000+** 篇论文，覆盖 NLP、CV、ML、DM、DB、Speech 等 40+ 个顶级会议与期刊。
+
+### 下阶段目标
+- 升级前后端技术栈，优化搜索体验与界面设计。
+- 重新部署并上线 Web 搜索服务，支持更高效的论文检索与浏览。
+
+### 项目历程
+PaperVault 最初 fork 自 [MLNLP-World/AI-Paper-Collector](https://github.com/MLNLP-World/AI-Paper-Collector)，现已作为独立项目持续发展。我们正在将其从一个静态论文清单工具，逐步建设为一个功能完善、数据丰富的在线学术搜索引擎。
+
 ## :open_book: 收录会议范围
 
 <!-- confs-list-start -->

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PaperVault 是一个用于收集和检索人工智能领域学术论文的全自
 > **本项目仍在积极施工中。**
 
 ### 当前阶段
-- 正在大幅扩展论文收录范围，重点补充 **2020 年至今** 的更多优质期刊（如 TIP、TPAMI、TKDE、TNNLS、TASLP、IJCV 等）和出版社论文清单。
+- 正在大幅扩展论文收录范围，重点补充 **2020 年至今** 的更多优质期刊（如 TIP、TPAMI、TKDE、TNNLS、TASLP、IJCV 等）以及主流出版社（如 IEEE、ACM、Springer、Elsevier 等）的论文清单。
 - 已通过自动化脚本和 GitHub Actions 批量为论文填充 **摘要（abstract）** 信息，提升检索价值。
 - 当前数据库已收录 **94,000+** 篇论文，覆盖 NLP、CV、ML、DM、DB、Speech 等 40+ 个顶级会议与期刊。
 


### PR DESCRIPTION
- Add 🚧 项目状态 / 🚧 Project Status section in both README.md and README.en.md
- Clarify current phase: expanding journals/publishers from 2020 onward and backfilling abstracts
- State next steps: upgrade frontend/backend and relaunch web search
- Include project history and 94,000+ paper coverage stats