### PR TITLE
fix: sanitize DBLP venue prefixes and add missing category color

### DIFF
--- a/discovery/dblp.py
+++ b/discovery/dblp.py
@@ -67,7 +67,7 @@ CONFERENCES: Dict[str, Dict[str, Any]] = {
     # --- 计算机图形学与多媒体 ---
     "mm":     {"root": "https://dblp.org/db/conf/mm/index.html",     "start_year": 2019, "name": "MM"},
     "vr":     {"root": "https://dblp.org/db/conf/vr/index.html",     "start_year": 2019, "name": "VR"},
-    "visualization": {"root": "https://dblp.org/db/conf/visualization/index.html", "start_year": 2019, "name": "IEEE VIS"},
+    "visualization": {"root": "https://dblp.org/db/conf/visualization/index.html", "start_year": 2019, "name": "IEEEVIS"},
     "siggraph": {"root": "https://dblp.org/db/conf/siggraph/index.html", "start_year": 2019, "name": "SIGGRAPH"},
     # --- 数据库/数据挖掘/内容检索 ---
     "kdd":    {"root": "https://dblp.org/db/conf/kdd/index.html",    "start_year": 2019, "name": "KDD"},
@@ -194,7 +194,7 @@ JOURNALS: Dict[str, Dict[str, Any]] = {
     "tochi": {"root": "https://dblp.org/db/journals/tochi/index.html", "start_year": 2019, "name": "TOCHI"},
     "ijhcs": {"root": "https://dblp.org/db/journals/ijhcs/index.html", "start_year": 2019, "name": "IJHCS"},
     "jacm":  {"root": "https://dblp.org/db/journals/jacm/index.html",  "start_year": 2019, "name": "JACM"},
-    "pieee": {"root": "https://dblp.org/db/journals/pieee/index.html", "start_year": 2019, "name": "Proc. IEEE"},
+    "pieee": {"root": "https://dblp.org/db/journals/pieee/index.html", "start_year": 2019, "name": "PROCIEEE"},
     "chinaf":{"root": "https://dblp.org/db/journals/chinaf/index.html","start_year": 2019, "name": "SCIS"},
     "bioinformatics":{"root":"https://dblp.org/db/journals/bioinformatics/index.html","start_year":2019,"name":"Bioinformatics"},
     # --- 已有期刊（保留历史名称映射）---

--- a/maintain.py
+++ b/maintain.py
@@ -44,7 +44,7 @@ meta_path = os.path.join(os.path.dirname(__file__), "cache", "readme_meta.json")
 NATURE_COLORS = [
     "#2E5C8A", "#7BA05B", "#C44E52", "#DD8452",
     "#9370DB", "#55A3B9", "#8C8C8C", "#E3A018",
-    "#4C4C4C", "#A0C4E8",
+    "#4C4C4C", "#A0C4E8", "#C49C94",
 ]
 
 # 按 CCF 第七版推荐目录分类（A 类为核心，同时包含项目已收录的其他会议/期刊）
@@ -75,7 +75,7 @@ CATEGORY_MAP = {
     ],
     "计算机图形学与多媒体": [
         "TOG", "TIP", "TVCG", "TMM",
-        "MM", "SIGGRAPH", "VR", "IEEE VIS", "BMVC", "MICCAI", "ICME",
+        "MM", "SIGGRAPH", "VR", "IEEEVIS", "BMVC", "MICCAI", "ICME",
     ],
     "人工智能": [
         "AI", "TPAMI", "IJCV", "JMLR",
@@ -90,7 +90,7 @@ CATEGORY_MAP = {
         "ICASSP", "INTERSPEECH", "TASLP",
     ],
     "交叉/综合/新兴": [
-        "JACM", "PROC. IEEE", "SCIS", "BIOINFORMATICS",
+        "JACM", "PROCIEEE", "SCIS", "BIOINFORMATICS",
         "RTSS", "ISWC",
     ],
 }
@@ -122,7 +122,7 @@ CATEGORY_MAP_EN = {
     ],
     "Computer Graphics & Multimedia": [
         "TOG", "TIP", "TVCG", "TMM",
-        "MM", "SIGGRAPH", "VR", "IEEE VIS", "BMVC", "MICCAI", "ICME",
+        "MM", "SIGGRAPH", "VR", "IEEEVIS", "BMVC", "MICCAI", "ICME",
     ],
     "Artificial Intelligence": [
         "AI", "TPAMI", "IJCV", "JMLR",
@@ -137,7 +137,7 @@ CATEGORY_MAP_EN = {
         "ICASSP", "INTERSPEECH", "TASLP",
     ],
     "Interdisciplinary / Comprehensive / Emerging": [
-        "JACM", "PROC. IEEE", "SCIS", "BIOINFORMATICS",
+        "JACM", "PROCIEEE", "SCIS", "BIOINFORMATICS",
         "RTSS", "ISWC",
     ],
 }


### PR DESCRIPTION
- discovery/dblp.py: Rename venue prefixes that contain spaces/punctuation to pure-letter forms so downstream regex ([A-Za-z]+)(\d{4}) in maintain.py can correctly parse conference keys for yearly stats and category counts.
    - IEEE VIS  -> IEEEVIS
    - Proc. IEEE -> PROCIEEE

- maintain.py:
  - Sync CATEGORY_MAP and CATEGORY_MAP_EN with the sanitized prefixes above (IEEE VIS -> IEEEVIS, PROC. IEEE -> PROCIEEE).
  - Add an 11th color (#C49C94) to NATURE_COLORS so that each of the 11 top-level categories has a unique color, eliminating the duplicate-color issue caused by modulo indexing in charts and improving readability of docs/stats.html.