### PR TITLE
fix(font): use fc-list reported family name instead of hard-coded guess

### DIFF
--- a/maintain.py
+++ b/maintain.py
@@ -409,7 +409,11 @@ def _find_cjk_font():
                 family = family_part.split(",")[0].strip()
                 match = _matches_candidate(os.path.basename(filepath))
                 if match:
-                    return match[0], filepath
+                    # Use the actual family name reported by fc-list instead of
+                    # the hard-coded candidate name. A .ttc file may contain
+                    # multiple sub-fonts (e.g. Mono vs Sans) and the hard-coded
+                    # name may not match what fontconfig reports.
+                    return family, filepath
                 # If filename doesn't match but family does, still trust fc-list
                 for expected_family, _ in candidates:
                     if expected_family.lower() in family.lower():


### PR DESCRIPTION
Root cause: on Ubuntu CI, fonts-noto-cjk installs NotoSansCJK-Bold.ttc whose actual family name is 'Noto Sans Mono CJK SC' (reported by fc-list), but _matches_candidate() returned the hard-coded 'Noto Sans CJK SC'. This mismatch caused matplotlib addfont() to register the font under the Mono family, while plt.rcParams['font.sans-serif'] pointed to the non-existent 'Noto Sans CJK SC', falling back to DejaVu Sans and producing missing-glyph warnings for all CJK characters.

Fix: return the actual family name from fc-list when the filename matches.