### PR TITLE
﻿feat(hf): publish dataset card with auto-synced statistics charts

### DIFF
--- a/.github/workflows/backfill_abstracts.yml
+++ b/.github/workflows/backfill_abstracts.yml
@@ -299,3 +299,11 @@ jobs:
             cache/abstract_backfill_progress.json
             docs/abstract_backfill_progress.md
             pics/stats/stats_overview.svg
+
+      - name: Sync Hugging Face dataset README
+        # Render docs/HF_README.md with the just-updated cache stats and push
+        # it to the HF dataset repo root as README.md. Runs unconditionally so
+        # the HF landing page reflects the latest abstract coverage even when
+        # no PR is opened back to GitHub.
+        if: always()
+        run: python scripts/sync_hf_readme.py --skip-cache-refresh

--- a/.github/workflows/collect_papers.yml
+++ b/.github/workflows/collect_papers.yml
@@ -265,3 +265,11 @@ jobs:
             cache/collect_progress.json
             cache/collect_failures.json
             README.md
+
+      - name: Sync Hugging Face dataset README
+        # Render docs/HF_README.md with the just-updated cache stats and push
+        # it to the HF dataset repo root as README.md. Always-run so that even
+        # if the PR-creation step is skipped (no new papers), the HF page
+        # still gets the latest "last updated" line.
+        if: always()
+        run: python scripts/sync_hf_readme.py --skip-cache-refresh

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -128,3 +128,11 @@ jobs:
             pics/stats/papers_by_year.svg
             pics/stats/wordcloud.svg
             docs/stats.html
+
+      - name: Sync Hugging Face dataset README
+        # Render docs/HF_README.md with the just-updated cache stats and push
+        # it to the HF dataset repo root as README.md. Always-run so the HF
+        # landing page is refreshed even when no GitHub-side diff is produced
+        # (e.g. README-only mode with no statistical movement).
+        if: always()
+        run: python scripts/sync_hf_readme.py --skip-cache-refresh

--- a/docs/HF_README.md
+++ b/docs/HF_README.md
@@ -1,0 +1,153 @@
+---
+license: gpl-3.0
+task_categories:
+  - text-retrieval
+  - text-classification
+language:
+  - zh
+  - en
+tags:
+  - papers
+  - academic
+  - bibliography
+  - nlp
+  - computer-vision
+  - machine-learning
+pretty_name: PaperVault
+size_categories:
+  - 100K<n<1M
+---
+
+# PaperVault Dataset · 论文元数据库
+
+## 🔎 项目简介 · Overview
+
+PaperVault 是一份**持续自动更新**的统一论文元数据库，覆盖自然语言处理、计算机视觉、机器学习、数据挖掘、数据库、语音、系统、网络、安全、理论计算机科学、人机交互、计算机图形学与多媒体等方向的顶级会议与期刊。PaperVault is a **continuously-updated, unified metadata database** of papers from top-tier conferences and journals across NLP, Computer Vision, Machine Learning, Data Mining, Databases, Speech, Systems, Networking, Security, Theory, HCI, Graphics, and Multimedia.
+
+> 🌐 源仓库 / Source: **[github.com/youngfish42/PaperVault](https://github.com/youngfish42/PaperVault)** — Web UI、REST API、采集流水线、Issues / PRs 全部在那里 · Web UI, REST API, crawling pipelines and issues/PRs all live there.
+
+---
+
+## 🆕 最近更新 · Recent Update
+
+<!-- hf-recent-update-start -->
+- 📅 **最近更新 · Last updated**: _等待首次同步 · pending first sync_
+- 📊 **数据库规模 · Database size**: _等待首次同步 · pending first sync_
+<!-- hf-recent-update-end -->
+
+---
+
+## 📈 数据看板 · Statistics at a Glance
+
+下列 4 张统计图与 `cache.jsonl.gz` 同源同步，反映本数据集的最新状态。The four charts below are generated from the same `cache.jsonl.gz` and always reflect the latest state of this dataset.
+
+<p align="center">
+  <img src="pics/stats/stats_overview.svg" alt="Statistics Overview" width="850" />
+</p>
+
+<p align="center">
+  <img src="pics/stats/papers_by_category.svg" alt="Papers by Research Field" width="850" />
+</p>
+
+<p align="center">
+  <img src="pics/stats/papers_by_year.svg" alt="Annual Paper Collection Trend" width="850" />
+</p>
+
+<p align="center">
+  <img src="pics/stats/wordcloud.svg" alt="Publication Series Word Cloud" width="900" />
+</p>
+
+---
+
+## 📦 数据集内容 · What's in this dataset
+
+| 路径 Path | 格式 Format | 说明 Description |
+|---|---|---|
+| `cache/cache.jsonl.gz` | gzip-compressed JSON Lines (UTF-8) | 每行一篇论文 · One paper per line; one JSON object per line |
+
+Hugging Face 会自动为 `cache.jsonl.gz` 生成 Parquet 视图，也可直接用 `datasets.load_dataset(...)` 读取，无需手动解压。Hugging Face also exposes an auto-generated Parquet view, so `datasets.load_dataset(...)` works out of the box.
+
+### 📐 字段 Schema
+
+| Field 字段 | Type 类型 | Notes 说明 |
+|---|---|---|
+| `paper_name` | string | 论文标题（已归一化）· Normalised paper title |
+| `paper_authors` | list[string] | 作者列表，按原始顺序 · Author names in order |
+| `paper_url` | string | 论文在原始平台的链接（PDF 或落地页）· Canonical URL on the venue's site (PDF or landing page) |
+| `paper_abstract` | string | 摘要；未回填时为空字符串 · Abstract; may be empty when not yet backfilled |
+| `paper_code` | string | 从摘要中抽取出的 GitHub 仓库 URL；`"#"` 是「未发现代码链接」的占位符 · GitHub repository URL extracted from the abstract; `"#"` is the sentinel for "no code link discovered" |
+| `conf` | string | 会议+年份标识，如 `ACL2024`、`NIPS2023`、`CVPR2025`；去掉末尾四位数字即可得到会议系列。注意 NeurIPS Proceedings 沿用历史命名 `NIPS{year}`。Venue + year identifier (e.g. `ACL2024`, `NIPS2023`, `CVPR2025`). Strip the trailing 4-digit year to recover the venue series. Note that NeurIPS Proceedings entries use the historical name `NIPS{year}`. |
+
+> 缺失字段请按空字符串处理。Treat missing fields as empty strings.
+
+---
+
+## ⬇️ 获取方式 · How to download
+
+下面三种方式任选其一即可，**无需克隆 GitHub 仓库**。Pick any one of the three options below — **no GitHub clone is required**.
+
+#### 方式 A · Option A — `huggingface_hub`（推荐 / recommended）
+
+```python
+from huggingface_hub import hf_hub_download
+import gzip, json
+
+path = hf_hub_download(
+    repo_id="youngfish42/PaperVault",
+    filename="cache/cache.jsonl.gz",
+    repo_type="dataset",
+)
+
+with gzip.open(path, "rt", encoding="utf-8") as f:
+    for line in f:
+        record = json.loads(line)
+        # 在这里处理一条记录 · do something with the record
+```
+
+#### 方式 B · Option B — `datasets`
+
+```python
+from datasets import load_dataset
+
+ds = load_dataset("youngfish42/PaperVault")
+print(ds[next(iter(ds))][0])
+```
+
+> 数据集只有一个默认 split（非 ML 训练集），不要传 `split="train"`。Single default split — do **not** pass `split="train"`.
+
+#### 方式 C · Option C — `huggingface-cli` / 直接 HTTPS · Plain HTTPS
+
+```bash
+huggingface-cli download youngfish42/PaperVault \
+    cache/cache.jsonl.gz --repo-type dataset --local-dir ./data
+```
+
+> 💡 文件压缩后约 120 MB（会随数据持续增长），解压后是 GB 级 JSONL 流，请按行流式读取，不要整体载入内存。The file is ~120 MB compressed (and growing) and decompresses to a multi-GB JSONL stream. Stream it line-by-line rather than loading the whole thing into memory.
+
+---
+
+## 🔁 更新节奏 · Update cadence
+
+数据集由三个 GitHub Actions 工作流负责重建并推送到本 Hub 仓库 / The dataset is rebuilt and pushed to this Hub repo by three GitHub Actions workflows：
+
+| 工作流 Workflow | 触发节奏 Schedule | 推送的内容 What it pushes |
+|---|---|---|
+| `collect_papers` | 每月 15 号 16:00 UTC + 手动触发 · 15th of every month at 16:00 UTC + `workflow_dispatch` | 增量抓取新发现的会议/年份组合 · Incremental crawl of newly-discovered conference/year combinations |
+| `backfill_abstracts` | 每月 1 号 00:00 UTC + 手动触发 · 1st of every month at 00:00 UTC + `workflow_dispatch` | 为已有论文回填 `paper_abstract` · Adds `paper_abstract` for papers that were collected without one |
+| `update_readme` | 仅手动触发 (`workflow_dispatch`) · Manual only (`workflow_dispatch`) | 默认仅刷新 README 与统计；当输入参数 `mode=force` 时执行全量重建 · Refreshes the README and statistics by default; performs a full rebuild only when invoked with `mode=force` |
+
+每次推送都使用 Hugging Face 的 `parent_commit` 乐观锁机制，避免并发覆盖。Each push uses Hugging Face's `parent_commit` optimistic-lock mechanism to avoid silently overwriting concurrent updates.
+
+---
+
+## 🔗 关联仓库 · Related repository
+
+如果你需要完整的搜索 Web UI（智能搜索 + Web of Science 风格的高级查询 DSL）、REST API（`/api/v1/*`）、抓取 / 合并 / 摘要回填流水线源码、收录会议范围、统计仪表盘、项目截图或贡献指南，请前往 GitHub 项目仓库。If you are looking for the full search Web UI (smart search + Web-of-Science-style advanced query DSL), the REST API (`/api/v1/*`), the crawling / merging / abstract-backfill pipelines source code, conference coverage, statistics dashboards, screenshots or contribution guidelines, please visit the GitHub repository.
+
+👉 **[github.com/youngfish42/PaperVault](https://github.com/youngfish42/PaperVault)**
+
+---
+
+## 📜 许可证 · License
+
+代码以 [GPL-3.0](https://github.com/youngfish42/PaperVault/blob/main/LICENSE) 发布；每条论文记录的著作权仍属于原作者 / 出版方，本数据集仅重新分发公开可获取的元数据与链接。Code is released under [GPL-3.0](https://github.com/youngfish42/PaperVault/blob/main/LICENSE); individual paper records remain the IP of their authors/publishers — this dataset only redistributes publicly available bibliographic metadata and links.

--- a/scripts/sync_hf_readme.py
+++ b/scripts/sync_hf_readme.py
@@ -1,0 +1,364 @@
+"""Render docs/HF_README.md with the latest cache statistics and push it
+to the Hugging Face dataset repo as the root-level README.md.
+
+This script is intentionally decoupled from data_artifacts.upload_to_huggingface:
+that helper computes the remote path from the local path relative to the
+project root, which would land the file at ``docs/HF_README.md`` on Hugging
+Face. The HF dataset hub only renders README.md placed at the repo root, so
+we call HfApi.upload_file directly with an explicit ``path_in_repo='README.md'``.
+
+The script is safe to invoke multiple times in a single workflow run; HF
+upload is idempotent (no-op when the file content is unchanged).
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import re
+import sys
+import time
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Dict, Optional
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from data_artifacts import (  # noqa: E402
+    DEFAULT_CACHE_PATH,
+    HF_UPLOAD_MAX_ATTEMPTS,
+    HF_UPLOAD_RETRY_BACKOFF,
+    _get_hf_api,
+    _get_remote_commit,
+    _hf_repo_id,
+    _hf_repo_type,
+    _is_stale_parent_commit_error,
+    ensure_cache_local,
+    upload_to_huggingface,
+)
+
+
+HF_README_TEMPLATE = ROOT / "docs" / "HF_README.md"
+RECENT_UPDATE_START = "<!-- hf-recent-update-start -->"
+RECENT_UPDATE_END = "<!-- hf-recent-update-end -->"
+HF_README_PATH_IN_REPO = "README.md"
+
+# Statistics SVGs that the HF README references via relative ``pics/stats/*.svg``
+# paths. We push them alongside the README so the HF dataset card always
+# renders the freshest charts. Order is irrelevant; upload_to_huggingface
+# silently skips entries whose local file does not exist (e.g. wordcloud
+# can be absent when the optional ``wordcloud`` package is not installed).
+HF_README_CHARTS = (
+    ROOT / "pics" / "stats" / "stats_overview.svg",
+    ROOT / "pics" / "stats" / "papers_by_category.svg",
+    ROOT / "pics" / "stats" / "papers_by_year.svg",
+    ROOT / "pics" / "stats" / "wordcloud.svg",
+)
+
+
+def _compute_stats(cache_path: Path) -> Dict[str, int]:
+    """Compute the headline numbers shown in the HF README banner.
+
+    The on-disk format is a JSON-Lines file (gzipped) where each line is one
+    paper record carrying a ``conf`` field such as ``"NeurIPS2024"``. We
+    deliberately mirror the counting rules used by ``maintain.compute_stats``
+    so the HF banner stays consistent with the GitHub README:
+
+    * ``total``           - one per non-empty line that parses as JSON.
+    * ``with_abstract``   - ``paper_abstract`` is a non-empty string.
+    * ``with_code``       - ``paper_code`` is non-empty AND not the ``"#"``
+                            placeholder that the collector writes when no
+                            code link was discovered.
+    * ``conf_series``     - number of distinct venue series, computed by
+                            stripping the trailing 4-digit year from each
+                            distinct ``conf`` value (so ``ACL2023`` and
+                            ``ACL2024`` collapse into the single ``ACL``
+                            series). Falls back to the raw key when the
+                            regex does not match.
+    """
+    total = 0
+    with_abstract = 0
+    with_code = 0
+    conf_keys: set = set()
+    if not cache_path.exists():
+        return {
+            "total": 0,
+            "with_abstract": 0,
+            "with_code": 0,
+            "conf_series": 0,
+        }
+    with gzip.open(cache_path, "rt", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            total += 1
+            if (record.get("paper_abstract") or "").strip():
+                with_abstract += 1
+            code_link = str(record.get("paper_code") or "").strip()
+            if code_link and code_link != "#":
+                with_code += 1
+            conf = (record.get("conf") or "").strip()
+            if conf:
+                conf_keys.add(conf)
+
+    series: set = set()
+    series_re = re.compile(r"^([A-Za-z]+)\d{4}$")
+    for key in conf_keys:
+        match = series_re.match(key)
+        series.add(match.group(1).upper() if match else key)
+
+    return {
+        "total": total,
+        "with_abstract": with_abstract,
+        "with_code": with_code,
+        "conf_series": len(series),
+    }
+
+
+def _render_recent_update_block(stats: Dict[str, int]) -> str:
+    now_cn = datetime.now(timezone(timedelta(hours=8))).strftime("%Y-%m-%d")
+    size_summary_en = (
+        f"{stats['total']:,} papers"
+        f" / {stats['conf_series']} venue series"
+        f" / {stats['with_abstract']:,} with abstract"
+        f" / {stats['with_code']:,} with code"
+    )
+    size_summary_zh = (
+        f"{stats['total']:,} 篇论文"
+        f" / {stats['conf_series']} 个刊物系列"
+        f" / {stats['with_abstract']:,} 篇含摘要"
+        f" / {stats['with_code']:,} 篇含开源代码"
+    )
+    lines = [
+        RECENT_UPDATE_START,
+        f"- 📅 **最近更新 · Last updated**: {now_cn} (Asia/Shanghai)",
+        f"- 📊 **数据库规模 · Database size**: {size_summary_zh}（{size_summary_en}）",
+        RECENT_UPDATE_END,
+    ]
+    return "\n".join(lines)
+
+
+def _render_readme(template_text: str, stats: Dict[str, int]) -> str:
+    start_idx = template_text.find(RECENT_UPDATE_START)
+    end_idx = template_text.find(RECENT_UPDATE_END)
+    if start_idx == -1 or end_idx == -1 or end_idx < start_idx:
+        # Defensive fallback: if markers are missing the template was edited
+        # in a way we cannot safely patch; surface a clear error rather than
+        # silently shipping an outdated HF README.
+        raise RuntimeError(
+            f"HF README template at {HF_README_TEMPLATE} is missing the "
+            f"'{RECENT_UPDATE_START}' / '{RECENT_UPDATE_END}' markers; "
+            "cannot inject the recent-update block."
+        )
+    end_idx_after = end_idx + len(RECENT_UPDATE_END)
+    return (
+        template_text[:start_idx]
+        + _render_recent_update_block(stats)
+        + template_text[end_idx_after:]
+    )
+
+
+def _upload_hf_readme(content: str, commit_message: str) -> bool:
+    repo_id = _hf_repo_id()
+    if not repo_id:
+        print("[*] PAPERVAULT_HF_REPO_ID is not set; skipping HF README sync.")
+        return False
+
+    api = _get_hf_api()
+    if api is None:
+        print(
+            "[!] huggingface_hub is not installed or auth failed; "
+            "skipping HF README sync."
+        )
+        return False
+
+    repo_type = _hf_repo_type()
+    payload = content.encode("utf-8")
+    parent_commit: Optional[str] = _get_remote_commit(api, repo_id, HF_README_PATH_IN_REPO)
+
+    max_attempts = max(1, HF_UPLOAD_MAX_ATTEMPTS)
+    backoff = max(0.0, HF_UPLOAD_RETRY_BACKOFF)
+    last_exc: Optional[Exception] = None
+
+    for attempt in range(1, max_attempts + 1):
+        kwargs = dict(
+            path_or_fileobj=payload,
+            path_in_repo=HF_README_PATH_IN_REPO,
+            repo_id=repo_id,
+            repo_type=repo_type,
+            commit_message=commit_message,
+        )
+        if parent_commit:
+            kwargs["parent_commit"] = parent_commit
+        try:
+            api.upload_file(**kwargs)
+            print(
+                f"[+] HF README synchronised to {repo_id}/{HF_README_PATH_IN_REPO}"
+            )
+            return True
+        except Exception as exc:
+            last_exc = exc
+            stale = _is_stale_parent_commit_error(exc)
+            print(
+                f"[!] HF README upload failed (attempt {attempt}/{max_attempts}): {exc}"
+            )
+            if stale and attempt < max_attempts:
+                new_head = _get_remote_commit(api, repo_id, HF_README_PATH_IN_REPO)
+                if new_head and new_head != parent_commit:
+                    print(
+                        f"[*] Stale parent_commit detected; rebasing on "
+                        f"new head {new_head} and retrying."
+                    )
+                    parent_commit = new_head
+                    continue
+            if attempt < max_attempts and backoff > 0:
+                sleep_for = backoff * (2 ** (attempt - 1))
+                print(f"[*] Retrying in {sleep_for:.1f}s ...")
+                time.sleep(sleep_for)
+
+    print(
+        f"[!] Giving up on HF README upload after {max_attempts} attempts. "
+        f"Last error: {last_exc}"
+    )
+    return False
+
+
+def _upload_stats_charts(commit_message: str) -> int:
+    """Push the statistics SVGs referenced by the HF README to the dataset repo.
+
+    Best-effort: returns the number of charts successfully uploaded. Failures
+    are logged but never raised, because the README has already been
+    synchronised at this point and a chart hiccup must not flip the workflow
+    step to a non-zero exit code (the GitHub Action that calls this script
+    treats any non-zero status as a hard failure of the data pipeline).
+
+    Charts that do not exist locally (e.g. when the optional ``wordcloud``
+    dependency was unavailable on the runner) are silently skipped by
+    ``upload_to_huggingface``.
+    """
+    existing = [p for p in HF_README_CHARTS if p.exists()]
+    missing = [p for p in HF_README_CHARTS if not p.exists()]
+    for path in missing:
+        # Surface a clear hint rather than dropping the chart silently;
+        # the corresponding ``<img>`` tag in the HF README will appear
+        # broken until the chart is generated by ``maintain.py``.
+        print(f"[*] HF chart skipped (not present locally): {path.relative_to(ROOT)}")
+
+    if not existing:
+        print("[*] No stats SVGs to upload; skipping chart sync.")
+        return 0
+
+    try:
+        uploaded = upload_to_huggingface(existing, commit_message)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        print(f"[!] HF chart upload raised unexpectedly; ignoring: {exc}")
+        return 0
+
+    for remote_path in uploaded:
+        print(f"[+] HF chart synchronised: {remote_path}")
+    if len(uploaded) < len(existing):
+        print(
+            f"[!] HF chart sync partial: {len(uploaded)}/{len(existing)} uploaded "
+            "(see warnings above)."
+        )
+    return len(uploaded)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Render the README locally and print a preview without uploading.",
+    )
+    parser.add_argument(
+        "--commit-message",
+        default="chore(auto): sync HF README from PaperVault GitHub workflow",
+        help="Commit message used for the Hugging Face upload.",
+    )
+    parser.add_argument(
+        "--skip-cache-refresh",
+        action="store_true",
+        help=(
+            "Skip the initial Hugging Face cache pull; useful when the caller "
+            "already has a fresh cache.jsonl.gz on disk (e.g. right after a "
+            "collect/backfill step in the same workflow)."
+        ),
+    )
+    parser.add_argument(
+        "--skip-charts",
+        action="store_true",
+        help=(
+            "Skip uploading the pics/stats/*.svg charts that the HF README "
+            "references. By default the script pushes them after the README "
+            "is synchronised so the HF dataset card always renders the "
+            "freshest figures."
+        ),
+    )
+    args = parser.parse_args()
+
+    if not HF_README_TEMPLATE.exists():
+        print(f"[!] HF README template not found: {HF_README_TEMPLATE}")
+        return 1
+
+    cache_path = Path(DEFAULT_CACHE_PATH)
+    if not args.skip_cache_refresh:
+        try:
+            cache_path, _ = ensure_cache_local(cache_path)
+        except Exception as exc:
+            print(
+                f"[!] Failed to refresh cache from Hugging Face ({exc}); "
+                "will compute stats from the local file if present."
+            )
+
+    stats = _compute_stats(cache_path)
+    print(
+        f"[+] cache stats: total={stats['total']} "
+        f"with_abstract={stats['with_abstract']} "
+        f"with_code={stats['with_code']} "
+        f"conf_series={stats['conf_series']}"
+    )
+
+    template_text = HF_README_TEMPLATE.read_text(encoding="utf-8")
+    rendered = _render_readme(template_text, stats)
+
+    if args.dry_run:
+        # Write to stdout via the raw buffer with UTF-8 to avoid
+        # UnicodeEncodeError on Windows consoles whose default codec is GBK
+        # (the README intentionally contains emoji and other non-BMP chars).
+        sys.stdout.write("--- BEGIN HF README PREVIEW ---\n")
+        sys.stdout.flush()
+        try:
+            sys.stdout.buffer.write(rendered.encode("utf-8"))
+            sys.stdout.buffer.write(b"\n")
+            sys.stdout.buffer.flush()
+        except AttributeError:
+            # Some test runners replace sys.stdout with a buffer-less stream.
+            sys.stdout.write(rendered + "\n")
+        sys.stdout.write("--- END HF README PREVIEW ---\n")
+        if not args.skip_charts:
+            existing = [p for p in HF_README_CHARTS if p.exists()]
+            print(
+                f"[dry-run] would upload {len(existing)} stats chart(s): "
+                + ", ".join(str(p.relative_to(ROOT)) for p in existing)
+            )
+        return 0
+
+    ok = _upload_hf_readme(rendered, args.commit_message)
+    if ok and not args.skip_charts:
+        # Run only when the README itself was uploaded successfully so we
+        # never publish charts that contradict a stale README banner.
+        _upload_stats_charts(args.commit_message)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
在 Hugging Face dataset 仓库发布一份独立的 README（区别于 GitHub README），并把 GitHub 上的 4 张英文统计图自动同步过去，确保 HF 数据看板与 cache.jsonl.gz 始终保持一致。

Changes:
- docs/HF_README.md: 新增 HF 平台 dataset card，含统计图 4 张、字段 schema、3 种下载方式；保留 <!-- hf-recent-update-* --> 占位符供脚本自动覆写最近更新区块。
- scripts/sync_hf_readme.py: 新增 _upload_stats_charts()，在 README 同步成功后顺带把 pics/stats/*.svg 推到 HF 仓库的同名相对路径，使 README 里的图片引用命中；新增 --skip-charts 开关；图片上传失败仅 warning，不影响脚本退出码。
- .github/workflows/{backfill_abstracts,collect_papers,update_readme}.yml: 在三条 cache-mutating 流水线末尾各加一个 if: always() 的 Sync Hugging Face dataset README step，调用 scripts/sync_hf_readme.py --skip-cache-refresh。

Design notes:
- 路径计算复用 data_artifacts._path_in_repo，远程路径 = relative_to(ROOT).as_posix()，因此本地 pics/stats/*.svg 落到 HF 的 pics/stats/*.svg，与 README 引用 1:1 对齐。
- 图同步严格放在 README 同步成功之后，避免 README 是新的、图是旧的 这种自相矛盾的中间快照。
- HF Hub 上传天然幂等：内容未变即 no-op，所以 backfill_abstracts 只重生 stats_overview.svg 的情况下，其余 3 张图不会产生空 commit。