### PR TITLE
fix(collector): 信源端 + 缓存合并双向去重，避免 abstract 丢失

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -136,6 +136,63 @@ def _fetch_openreview_abstract(forum_id: str) -> str:
     return ""
 
 
+def _better_str(prev: str, new: str) -> str:
+    """Return whichever string carries more information.
+
+    Used during in-batch and cache-merge dedupe: when two records describe the
+    same paper, prefer the longer non-empty value so we never silently drop an
+    abstract that was filled by a later collector pass or by a backfill
+    workflow.
+    """
+    prev = prev or ""
+    new = new or ""
+    if not prev:
+        return new
+    if not new:
+        return prev
+    return new if len(new) > len(prev) else prev
+
+
+def _better_list(prev, new):
+    """Same intent as ``_better_str`` but for author lists."""
+    prev = prev or []
+    new = new or []
+    if not prev:
+        return new
+    if not new:
+        return prev
+    return new if len(new) > len(prev) else prev
+
+
+def _better_code(prev: str, new: str) -> str:
+    """Prefer a real code link over the ``'#'`` placeholder."""
+    prev = (prev or "").strip()
+    new = (new or "").strip()
+    if prev and prev != "#":
+        return prev
+    if new and new != "#":
+        return new
+    return prev or new or "#"
+
+
+def _merge_paper_record(existing: dict, incoming: dict) -> None:
+    """Field-level merge of two paper dicts that share the same dedupe key.
+
+    The caller has already decided ``existing`` and ``incoming`` describe the
+    same paper. We enrich ``existing`` in place by taking the longer abstract,
+    the longer author list, and any non-placeholder code link.
+    """
+    existing["paper_abstract"] = _better_str(
+        existing.get("paper_abstract"), incoming.get("paper_abstract")
+    )
+    existing["paper_authors"] = _better_list(
+        existing.get("paper_authors"), incoming.get("paper_authors")
+    )
+    existing["paper_code"] = _better_code(
+        existing.get("paper_code"), incoming.get("paper_code")
+    )
+
+
 def _url_targets_rejected_venue(url: str) -> bool:
     """快速判断一条 OpenReview 抓取 URL 是否指向「未接收」venue。
 
@@ -167,6 +224,19 @@ def search_from_iclr_openreview(url, name, res):
     """
     if name not in res:
         res[name] = []
+
+    # In-batch dedupe by OpenReview forum_id. The same forum_id can be returned
+    # more than once when (a) the v1 endpoint partially succeeds before we fall
+    # back to v2, (b) the API duplicates a note across offset boundaries, or
+    # (c) a previous run already appended the same paper to ``res[name]``.
+    # We track existing forum_ids on entry so re-invocations of the same
+    # (url, name) pair are idempotent and we merge late-arriving abstracts
+    # instead of silently dropping them.
+    seen_ids: dict = {}
+    for existing in res[name]:
+        fid = _extract_forum_id(existing.get("paper_url") or "")
+        if fid:
+            seen_ids[fid] = existing
 
     # 源头过滤：若 URL 本身指向 Submitted/Withdrawn/Rejected 等未接收 venue，
     # 直接跳过，避免拉取大量必然被 _is_openreview_accepted 丢弃的论文。
@@ -213,15 +283,24 @@ def search_from_iclr_openreview(url, name, res):
                     paper_authors = []
                 abstract = _or_field(content, "abstract") or ""
 
-                res[name].append(
-                    {
-                        "paper_name": title,
-                        "paper_url": "https://openreview.net/pdf?id=" + item["id"],
-                        "paper_authors": paper_authors,
-                        "paper_abstract": abstract,
-                        "paper_code": "#",
-                    }
-                )
+                forum_id = item.get("id") or ""
+                record = {
+                    "paper_name": title,
+                    "paper_url": "https://openreview.net/pdf?id=" + forum_id,
+                    "paper_authors": paper_authors,
+                    "paper_abstract": abstract,
+                    "paper_code": "#",
+                }
+                prior = seen_ids.get(forum_id) if forum_id else None
+                if prior is not None:
+                    # Same forum_id reappeared (offset boundary, v1->v2
+                    # fallback or re-run). Merge enriched fields into the
+                    # already-stored record and skip the duplicate append.
+                    _merge_paper_record(prior, record)
+                    continue
+                res[name].append(record)
+                if forum_id:
+                    seen_ids[forum_id] = record
                 got_in_this_variant += 1
 
             if len(notes) < limit:
@@ -307,6 +386,15 @@ def search_from_iclr_official(url, name, res):
     if name not in res:
         res[name] = []
 
+    # In-batch dedupe: keep one record per OpenReview forum_id, even if the
+    # schedule page (or a previous run that already appended into ``res[name]``)
+    # lists the same paper twice.
+    seen_ids: dict = {}
+    for existing in res[name]:
+        fid = _extract_forum_id(existing.get("paper_url") or "")
+        if fid:
+            seen_ids[fid] = existing
+
     r = SESSION.get(url, headers=HEADERS)
     soup = BeautifulSoup(r.text, "html.parser")
 
@@ -343,8 +431,20 @@ def search_from_iclr_official(url, name, res):
             "paper_abstract": "",  # 占位，稍后批量回填
             "paper_code": "#",
         }
+        forum_id = _extract_forum_id(paper_url)
+        prior = seen_ids.get(forum_id) if forum_id else None
+        if prior is not None:
+            # Same paper already collected (page duplication or prior run).
+            # Merge any non-empty fields we just parsed into the stored record
+            # and queue *that* one for the abstract backfill so the merged
+            # record gets enriched.
+            _merge_paper_record(prior, item)
+            new_items.append(prior)
+            continue
         res[name].append(item)
         new_items.append(item)
+        if forum_id:
+            seen_ids[forum_id] = item
 
     # 从源头批量回填 abstract，避免遗留给 fetch_abstracts.py
     forum_ids = []
@@ -400,6 +500,10 @@ def search_from_nips(url, name, res):
     soup = BeautifulSoup(r.text, "html.parser")
     if name not in res:
         res[name] = []
+    # In-batch dedupe by absolute paper URL. NeurIPS proceedings pages are
+    # single-volume so this mainly catches the "we already ran for this conf
+    # earlier in the session" case.
+    seen_urls: dict = {p["paper_url"]: p for p in res[name] if p.get("paper_url")}
     url_prefix = "https://" + url[8:].split("/")[0]
     col = soup.find(class_="col")
     if not col or not col.ul:
@@ -428,15 +532,19 @@ def search_from_nips(url, name, res):
             paper_abstract = ""
 
         paper_name = a_tag.string if a_tag.string else a_tag.get_text(strip=True)
-        res[name].append(
-            {
-                "paper_name": paper_name,
-                "paper_url": paper_url,
-                "paper_authors": paper_author,
-                "paper_abstract": paper_abstract,
-                "paper_code": "#",
-            }
-        )
+        record = {
+            "paper_name": paper_name,
+            "paper_url": paper_url,
+            "paper_authors": paper_author,
+            "paper_abstract": paper_abstract,
+            "paper_code": "#",
+        }
+        prior = seen_urls.get(paper_url)
+        if prior is not None:
+            _merge_paper_record(prior, record)
+            continue
+        res[name].append(record)
+        seen_urls[paper_url] = record
     return res
 
 
@@ -444,6 +552,11 @@ def _parse_acl_volume(volume_url: str, tag: str, name: str, res: dict):
     """解析 ACL Anthology 单个 volume 页面"""
     if name not in res:
         res[name] = []
+    # In-batch dedupe by anthology paper URL. ACL events span multiple
+    # volumes (main / findings / short / long ...) and ``search_from_acl``
+    # may invoke us once per volume; the same volume should never produce
+    # duplicates but a re-run after a partial failure can.
+    seen_urls: dict = {p["paper_url"]: p for p in res[name] if p.get("paper_url")}
     r = SESSION.get(volume_url, headers=HEADERS)
     soup = BeautifulSoup(r.text, "html.parser")
 
@@ -485,15 +598,19 @@ def _parse_acl_volume(volume_url: str, tag: str, name: str, res: dict):
         abstract_div = soup.find(id=f"abstract-{paper_id}")
         paper_abstract = abstract_div.text.strip() if abstract_div else ""
 
-        res[name].append(
-            {
-                "paper_name": paper,
-                "paper_url": paper_url,
-                "paper_authors": paper_authors,
-                "paper_abstract": paper_abstract,
-                "paper_code": "#",
-            }
-        )
+        record = {
+            "paper_name": paper,
+            "paper_url": paper_url,
+            "paper_authors": paper_authors,
+            "paper_abstract": paper_abstract,
+            "paper_code": "#",
+        }
+        prior = seen_urls.get(paper_url)
+        if prior is not None:
+            _merge_paper_record(prior, record)
+            continue
+        res[name].append(record)
+        seen_urls[paper_url] = record
     return res
 
 
@@ -593,6 +710,11 @@ def search_from_dblp(url, name, res):
     if name not in res:
         res[name] = []
 
+    # In-batch dedupe by external paper URL. DBLP multi-volume conferences
+    # (ECCV/AAAI/IJCAI ...) call this function once per volume, and the same
+    # entry can occasionally surface in more than one listing page.
+    seen_urls: dict = {p["paper_url"]: p for p in res[name] if p.get("paper_url")}
+
     for paper_item in soup.find_all("li", class_="entry"):
         drop_down = paper_item.find("li", class_="drop-down")
         if not drop_down or not drop_down.div or not drop_down.div.a:
@@ -619,15 +741,19 @@ def search_from_dblp(url, name, res):
             paper_abstract = ""
         if paper and paper[-1] == ".":
             paper = paper[:-1]
-        res[name].append(
-            {
-                "paper_name": paper, 
-                "paper_url": paper_url,
-                "paper_authors": paper_authors,
-                "paper_abstract": paper_abstract,
-                "paper_code": "#",
-            }
-        )
+        record = {
+            "paper_name": paper,
+            "paper_url": paper_url,
+            "paper_authors": paper_authors,
+            "paper_abstract": paper_abstract,
+            "paper_code": "#",
+        }
+        prior = seen_urls.get(paper_url)
+        if prior is not None:
+            _merge_paper_record(prior, record)
+            continue
+        res[name].append(record)
+        seen_urls[paper_url] = record
     return res
 
 
@@ -644,7 +770,12 @@ def search_from_thecvf(url, name, res):
     soup = BeautifulSoup(r.text, "html.parser")
     if name not in res:
         res[name] = []
-        
+
+    # In-batch dedupe by absolute paper URL. theCVF day-split pages
+    # (day1.py / day2.py / ALL.py) historically share entries, so the same
+    # paper may appear on more than one collected URL within a run.
+    seen_urls: dict = {p["paper_url"]: p for p in res[name] if p.get("paper_url")}
+
     for paper_item in soup.find_all("dt", class_="ptitle"):
         a_tag = paper_item.a
         if a_tag is None:
@@ -657,28 +788,32 @@ def search_from_thecvf(url, name, res):
             url_postfix = url_postfix[1:]
         paper_url = "https://openaccess.thecvf.com/" + href
         paper = a_tag.string if a_tag.string else a_tag.get_text(strip=True)
-        
+
         authors = []
         ns = paper_item.next_sibling
         if ns:
             ns2 = ns.next_sibling
             if ns2:
                 authors = [author.string for author in ns2.find_all('a', href='#') if author.string]
-        
+
         try:
             paper_abstract = search_abs_from_thecvf(paper_url)
         except:
             print(f"Skip url:{paper_url}")
             paper_abstract = ""
-        res[name].append(
-            {
-                "paper_name": paper, 
-                "paper_url": paper_url,
-                "paper_authors": authors,
-                "paper_abstract": paper_abstract,
-                "paper_code": "#",
-            }
-        )
+        record = {
+            "paper_name": paper,
+            "paper_url": paper_url,
+            "paper_authors": authors,
+            "paper_abstract": paper_abstract,
+            "paper_code": "#",
+        }
+        prior = seen_urls.get(paper_url)
+        if prior is not None:
+            _merge_paper_record(prior, record)
+            continue
+        res[name].append(record)
+        seen_urls[paper_url] = record
     return res
 
 
@@ -739,15 +874,36 @@ def save_collect_progress(progress):
 
 
 def _merge_with_cache(new_res, cache_res, multi_volume_names, collected_dblp_names):
+    """Merge ``cache_res`` (loaded from cache.jsonl.gz) into ``new_res``.
+
+    Historically this function only deduped URLs for multi-volume DBLP confs,
+    which let non-DBLP venues silently accumulate the same paper across reruns.
+    We now:
+
+    * Keep the old "drop the cache entirely if we did not recollect this conf"
+      branch (``conf_name not in result``) — used to copy untouched cache
+      records straight through.
+    * For every conf we *did* recollect, URL-dedupe the cache against the new
+      records and field-merge (longer abstract / authors / non-placeholder
+      code) so cache abstracts survive a fresh source run.
+    """
     result = dict(new_res)
     for conf_name, papers in cache_res.items():
         if conf_name not in result:
             result[conf_name] = papers
-        elif conf_name in multi_volume_names and conf_name in collected_dblp_names:
-            existing_urls = {p["paper_url"] for p in result[conf_name]}
-            for p in papers:
-                if p["paper_url"] not in existing_urls:
-                    result[conf_name].append(p)
+            continue
+        url_index: dict = {p["paper_url"]: p for p in result[conf_name] if p.get("paper_url")}
+        for p in papers:
+            paper_url = p.get("paper_url")
+            if not paper_url:
+                result[conf_name].append(p)
+                continue
+            prior = url_index.get(paper_url)
+            if prior is None:
+                result[conf_name].append(p)
+                url_index[paper_url] = p
+            else:
+                _merge_paper_record(prior, p)
     return result
 
 

--- a/tests/test_collector_dedupe.py
+++ b/tests/test_collector_dedupe.py
@@ -1,0 +1,296 @@
+"""Unit tests for the in-batch / cache-merge dedupe added by PR A.
+
+These cover the three duplication paths that the audit on ``cache.jsonl.gz``
+flagged as common sources of repeated rows:
+
+* OpenReview returning the same forum_id across pagination boundaries
+  (or across the v1->v2 fallback inside ``search_from_iclr_openreview``).
+* ACL multi-volume parsing where the same paper URL surfaces from two
+  ``_parse_acl_volume`` invocations within one collect run.
+* ``_merge_with_cache`` folding cache rows into a freshly recollected
+  conf without ever dropping a non-empty abstract.
+
+All tests are fully offline: ``SESSION.get`` is monkey-patched and
+``_parse_acl_volume`` is exercised against an in-memory HTML fixture, so
+no network access is required.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+
+import collector
+
+
+# ---------------------------------------------------------------------------
+# OpenReview pagination / v1->v2 fallback dedupe
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal stand-in for ``requests.Response`` that only needs ``.json()``."""
+
+    def __init__(self, payload: Dict[str, Any]):
+        self._payload = payload
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+
+def _make_note(forum_id: str, title: str, abstract: str, venue: str = "ICLR 2024 Poster") -> Dict[str, Any]:
+    return {
+        "id": forum_id,
+        "content": {
+            "title": title,
+            "authors": ["Alice"],
+            "abstract": abstract,
+            "venue": venue,
+        },
+    }
+
+
+def test_openreview_dedupes_repeated_forum_id(monkeypatch: pytest.MonkeyPatch):
+    """A forum_id that already exists in ``res[name]`` (e.g. from a previous
+    OpenReview URL in the same collect run, or from the v1->v2 fallback path)
+    must not be appended a second time. The longer abstract from the second
+    occurrence must win."""
+
+    page = {
+        "notes": [
+            # Duplicate of an entry already in res[name], now with a real
+            # abstract — should merge into the prior record, not append.
+            _make_note("aaa", "Paper A", "Long abstract for A"),
+            _make_note("bbb", "Paper B", "Short B"),
+        ]
+    }
+
+    pages = iter([page, {"notes": []}])
+
+    def fake_get(url, headers=None, timeout=None):  # noqa: ARG001
+        try:
+            return _FakeResponse(next(pages))
+        except StopIteration:
+            return _FakeResponse({"notes": []})
+
+    monkeypatch.setattr(collector.SESSION, "get", fake_get)
+
+    # Pre-seed with an existing record for forum_id 'aaa' that has an empty
+    # abstract — emulates the v1 endpoint having appended a placeholder before
+    # the v2 fallback re-serves the same paper with a real abstract.
+    res: Dict[str, List[dict]] = {
+        "ICLR 2024": [
+            {
+                "paper_name": "Paper A",
+                "paper_url": "https://openreview.net/pdf?id=aaa",
+                "paper_authors": ["Alice"],
+                "paper_abstract": "",
+                "paper_code": "#",
+            }
+        ]
+    }
+    collector.search_from_iclr_openreview(
+        "https://api.openreview.net/notes?content.venue=ICLR%202024%20Poster",
+        "ICLR 2024",
+        res,
+    )
+
+    papers = res["ICLR 2024"]
+    forum_ids = [p["paper_url"].rsplit("=", 1)[-1] for p in papers]
+    assert forum_ids.count("aaa") == 1, "duplicate forum_id must collapse"
+    assert sorted(forum_ids) == ["aaa", "bbb"]
+
+    # The merged record should carry the *longer* abstract that arrived second.
+    paper_a = next(p for p in papers if p["paper_url"].endswith("=aaa"))
+    assert paper_a["paper_abstract"] == "Long abstract for A"
+
+
+def test_openreview_idempotent_across_reruns(monkeypatch: pytest.MonkeyPatch):
+    """Calling search_from_iclr_openreview twice with the same data must not
+    double the result list — the second pass should merge into existing
+    records keyed by forum_id."""
+
+    base_page = {
+        "notes": [
+            _make_note("aaa", "Paper A", "abs A"),
+        ]
+    }
+
+    def fake_get_factory():
+        pages = iter([base_page, {"notes": []}])
+
+        def _fake_get(url, headers=None, timeout=None):  # noqa: ARG001
+            try:
+                return _FakeResponse(next(pages))
+            except StopIteration:
+                return _FakeResponse({"notes": []})
+
+        return _fake_get
+
+    monkeypatch.setattr(collector.SESSION, "get", fake_get_factory())
+
+    res: Dict[str, List[dict]] = {}
+    collector.search_from_iclr_openreview("https://api.openreview.net/notes?x=1", "ICLR 2024", res)
+    first_count = len(res["ICLR 2024"])
+
+    # Second pass with a fresh fake iterator: same data again.
+    monkeypatch.setattr(collector.SESSION, "get", fake_get_factory())
+    collector.search_from_iclr_openreview("https://api.openreview.net/notes?x=1", "ICLR 2024", res)
+
+    assert len(res["ICLR 2024"]) == first_count == 1
+
+
+# ---------------------------------------------------------------------------
+# ACL volume dedupe
+# ---------------------------------------------------------------------------
+
+
+_ACL_VOLUME_HTML = """
+<html><body>
+<p>
+  <strong><a href="/2023.acl-long.1/">Paper One</a></strong>
+  <a href="/people/a/alice/">Alice</a>
+</p>
+<div id="abstract-2023--acl-long--1">Long-form abstract one.</div>
+
+<p>
+  <strong><a href="/2023.acl-long.2/">Paper Two</a></strong>
+  <a href="/people/b/bob/">Bob</a>
+</p>
+<div id="abstract-2023--acl-long--2">Long-form abstract two.</div>
+</body></html>
+"""
+
+
+def _patch_acl_get(monkeypatch: pytest.MonkeyPatch, html: str) -> None:
+    monkeypatch.setattr(
+        collector.SESSION,
+        "get",
+        lambda url, headers=None: SimpleNamespace(text=html),
+    )
+
+
+def test_parse_acl_volume_dedupes_repeated_invocations(monkeypatch: pytest.MonkeyPatch):
+    """Calling _parse_acl_volume twice for the same volume URL must not
+    yield duplicate paper rows; merge logic must still update abstracts."""
+
+    _patch_acl_get(monkeypatch, _ACL_VOLUME_HTML)
+
+    res: Dict[str, List[dict]] = {}
+    collector._parse_acl_volume(
+        "https://aclanthology.org/volumes/2023.acl-long/", "^/2023.acl*", "ACL 2023", res
+    )
+    first = len(res["ACL 2023"])
+    assert first == 2
+
+    collector._parse_acl_volume(
+        "https://aclanthology.org/volumes/2023.acl-long/", "^/2023.acl*", "ACL 2023", res
+    )
+    assert len(res["ACL 2023"]) == first, "second invocation must not add duplicates"
+
+
+# ---------------------------------------------------------------------------
+# _merge_with_cache: URL dedupe + abstract merge across all confs
+# ---------------------------------------------------------------------------
+
+
+def test_merge_with_cache_preserves_cache_abstract_on_empty_recollect():
+    """The freshly recollected record has an empty abstract; the cached one
+    has the real abstract. The merged result must keep the cache abstract."""
+
+    new_res = {
+        "ICLR 2024": [
+            {
+                "paper_name": "X",
+                "paper_url": "https://openreview.net/pdf?id=xxx",
+                "paper_authors": ["Alice"],
+                "paper_abstract": "",
+                "paper_code": "#",
+            }
+        ]
+    }
+    cache_res = {
+        "ICLR 2024": [
+            {
+                "paper_name": "X",
+                "paper_url": "https://openreview.net/pdf?id=xxx",
+                "paper_authors": ["Alice"],
+                "paper_abstract": "Cached abstract.",
+                "paper_code": "https://github.com/foo/bar",
+            }
+        ]
+    }
+
+    merged = collector._merge_with_cache(new_res, cache_res, set(), set())
+    papers = merged["ICLR 2024"]
+    assert len(papers) == 1
+    assert papers[0]["paper_abstract"] == "Cached abstract."
+    assert papers[0]["paper_code"] == "https://github.com/foo/bar"
+
+
+def test_merge_with_cache_dedupes_non_dblp_conf():
+    """Pre-PR-A this branch only deduped multi-volume DBLP confs; verify
+    other confs also dedupe by URL now."""
+
+    new_res = {
+        "NeurIPS 2023": [
+            {
+                "paper_name": "Y",
+                "paper_url": "https://proceedings.neurips.cc/y",
+                "paper_authors": ["A"],
+                "paper_abstract": "fresh abs",
+                "paper_code": "#",
+            }
+        ]
+    }
+    cache_res = {
+        "NeurIPS 2023": [
+            {
+                "paper_name": "Y",
+                "paper_url": "https://proceedings.neurips.cc/y",
+                "paper_authors": ["A"],
+                "paper_abstract": "cached abs that is longer than the fresh one",
+                "paper_code": "#",
+            },
+            {
+                "paper_name": "Z",
+                "paper_url": "https://proceedings.neurips.cc/z",
+                "paper_authors": ["B"],
+                "paper_abstract": "",
+                "paper_code": "#",
+            },
+        ]
+    }
+
+    merged = collector._merge_with_cache(new_res, cache_res, set(), set())
+    papers = merged["NeurIPS 2023"]
+    urls = [p["paper_url"] for p in papers]
+    # "y" must appear exactly once (URL-deduped), and the longer (cached)
+    # abstract must win because of the field-merge in _merge_paper_record.
+    assert urls.count("https://proceedings.neurips.cc/y") == 1
+    paper_y = next(p for p in papers if p["paper_url"].endswith("/y"))
+    assert paper_y["paper_abstract"] == "cached abs that is longer than the fresh one"
+    # "z" was only in cache, must be carried over.
+    assert "https://proceedings.neurips.cc/z" in urls
+
+
+def test_merge_with_cache_keeps_untouched_confs():
+    """If a conf is in cache but not in new_res, it should be passed through
+    unchanged (the legacy ``conf_name not in result`` branch)."""
+
+    new_res: Dict[str, List[dict]] = {}
+    cache_res = {
+        "CVPR 2024": [
+            {
+                "paper_name": "P",
+                "paper_url": "https://openaccess.thecvf.com/p",
+                "paper_authors": [],
+                "paper_abstract": "cached",
+                "paper_code": "#",
+            }
+        ]
+    }
+    merged = collector._merge_with_cache(new_res, cache_res, set(), set())
+    assert merged["CVPR 2024"] == cache_res["CVPR 2024"]


### PR DESCRIPTION
## Why

`cache.jsonl.gz` 离线审计显示约 6.7% 重复行（44,689 行），且 104 个
论文组若按 `pid = sha1(conf|year|title)[:16]` 简单去重会丢失非空
abstract。根因有两条互相叠加：

1. **信源端**：`search_from_*` 系列函数没有批内 `seen`。OpenReview 分页
   边界、v1→v2 fallback、ACL 多 volume、theCVF day-split 都会把同一篇
   论文反复 `append` 到 `res[name]`。
2. **缓存合并端**：`_merge_with_cache` 只对多卷 DBLP conf 做 URL 去重，
   ICLR / NeurIPS / theCVF / ACL 等单卷 conf 每次重跑都会把旧缓存平铺
   叠加到新结果上，几小时内就能堆出 size-6 重复组。

## What

- 新增字段级合并辅助 `_merge_paper_record`（取更长 abstract / 作者
  列表 / 非占位 code），从设计上消除「去重导致摘要丢失」。
- 6 个 `search_from_*` 函数加批内 `seen`：ICLR 用 `forum_id`，其余用
  `paper_url`，命中时调用 `_merge_paper_record`。
- 重写 `_merge_with_cache`，对所有重新采集的 conf 做 URL 去重 + 字段
  合并；conf 未重采时整段直传缓存（保持旧行为）。

## Tests

- 新增 `tests/test_collector_dedupe.py`，6 个离线最小用例覆盖三类重复
  来源：OpenReview 分页 / cache 合并 / ACL volume。
- `pytest`：30 passed in ~4s。
- `GetDiagnostics` 对 `collector.py` 与新测试文件无告警。

## Out of scope

存量重复行（~6.7%）由 **PR B（fix/cache-cleanup）** 处理：基于 `main`
起一次性脚本，按 `pid` 分桶 → 字段级合并 → 流式重写 `cache.jsonl.gz`
+ 备份。本 PR 合入后即可启动。

## Risk

- `_merge_with_cache` 行为变化是面向**所有 conf** 的，理论上可能让某些
  「旧缓存被有意保留为重复」的 case 数量减少；但审计未发现这类合法
  重复，且 fallback 行为（conf 未重采时整段保留）维持原样。
- `search_from_iclr_official` 把命中 `seen_ids` 的论文记录仍加入
  `new_items`，确保后续 `_batch_fetch_openreview_abstracts` 仍会回填
  abstract 到合并后的记录上。