### PR TITLE
Fix/collect failures path

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -857,6 +857,7 @@ def add_code_links(res):
     return res
 
 COLLECT_PROGRESS_FILE = "cache/collect_progress.json"
+COLLECT_FAILURES_FILE = "cache/collect_failures.json"
 
 
 def load_collect_progress():
@@ -1063,8 +1064,9 @@ def collect(cache_file=None, force=False, soft_timeout=None):
 
     res = add_code_links(final_res)
 
-    failures_path = os.path.join(os.path.dirname(cache_file) if cache_file else ".", "collect_failures.json")
+    failures_path = COLLECT_FAILURES_FILE
     try:
+        os.makedirs(os.path.dirname(failures_path) or ".", exist_ok=True)
         with open(failures_path, "w", encoding="utf-8") as f:
             json.dump(failures, f, ensure_ascii=False, indent=2)
         if failures:

--- a/collector.py
+++ b/collector.py
@@ -1063,14 +1063,14 @@ def collect(cache_file=None, force=False, soft_timeout=None):
 
     res = add_code_links(final_res)
 
-    if failures:
-        failures_path = os.path.join(os.path.dirname(cache_file) if cache_file else ".", "collect_failures.json")
-        try:
-            with open(failures_path, "w", encoding="utf-8") as f:
-                json.dump(failures, f, ensure_ascii=False, indent=2)
+    failures_path = os.path.join(os.path.dirname(cache_file) if cache_file else ".", "collect_failures.json")
+    try:
+        with open(failures_path, "w", encoding="utf-8") as f:
+            json.dump(failures, f, ensure_ascii=False, indent=2)
+        if failures:
             print(f"[!] {len(failures)} conference(s) failed. Details saved to {failures_path}")
-        except Exception as e:
-            print(f"[!] Could not save failure log: {e}")
+    except Exception as e:
+        print(f"[!] Could not save failure log: {e}")
 
     return res
 

--- a/maintain.py
+++ b/maintain.py
@@ -13,7 +13,7 @@ matplotlib.use("Agg")
 import matplotlib.font_manager as fm
 import matplotlib.pyplot as plt
 
-from collector import collect, save_cache, load_cache
+from collector import collect, save_cache, load_cache, COLLECT_FAILURES_FILE
 from data_artifacts import ensure_cache_local, sync_cache_artifacts
 
 try:
@@ -1007,7 +1007,7 @@ def incremental_update(soft_timeout=None):
     if new_confs:
         print(f"    New conferences: {', '.join(sorted(new_confs))}")
 
-    failures_path = os.path.join(os.path.dirname(cache_path), "collect_failures.json")
+    failures_path = COLLECT_FAILURES_FILE
     if os.path.exists(failures_path):
         try:
             with open(failures_path, "r", encoding="utf-8") as f:


### PR DESCRIPTION
## 背景 / 故障现象

定时任务 `Collect Papers` 在 PR 创建阶段失败：
- 失败 run: https://github.com/youngfish42/PaperVault/actions/runs/28311776430/job/83877774737
- 关键报错： 

> /usr/bin/git add -- cache/collect_progress.json cache/collect_failures.json README.md
> fatal: pathspec 'cache/collect_failures.json' did not match any files
> ...
> no changes added to commit
> Error: Unexpected error:


## 根因

1. `.github/workflows/collect_papers.yml` 在两个位置都把 `cache/collect_failures.json` 列入了路径白名单：
 - `env.AUTO_COLLECT_FILES`（用于 hash 基线比对）
 - `peter-evans/create-pull-request@v6` 的 `add-paths`（用于 PR 提交白名单）
2. 但 `collector.collect()` 旧逻辑只在 `if failures:` 时才写出该文件，**无失败的成功 run 根本不会产生这个文件**。
3. `peter-evans/create-pull-request` 底层执行 `git add -- <paths>`，git 对任何不匹配的 pathspec 都会 `fatal` 退出，于是整个 workflow 红掉。
4. 此外，`maintain.force_update()` 传入 `cache_file=None`，旧代码会把失败日志落到 `./collect_failures.json`（仓库根目录），既不在 workflow 白名单内，也不在 `.gitignore` 中——属于潜在污染。

## 修复

- `collector.py`
- 新增常量 `COLLECT_FAILURES_FILE = "cache/collect_failures.json"`，与既有 `COLLECT_PROGRESS_FILE` 命名/位置对齐。
- `collect()` **始终写出** 失败日志（空时写 `[]`），并固定到 `COLLECT_FAILURES_FILE`，不再随 `cache_file` 参数漂移。
- 增加 `os.makedirs(..., exist_ok=True)` 兜底，避免全新 checkout 下 `cache/` 缺失时抛 `FileNotFoundError`。
- 仅在 `failures` 非空时打印告警，避免噪声。
- `maintain.py`
- `incremental_update()` 读取端也改用 `COLLECT_FAILURES_FILE`，消除读写两端路径漂移的风险。

## 影响面分析

- **incremental 路径**（定时 cron / `python maintain.py collect`）：文件位置不变，仍为 `cache/collect_failures.json`；只是无失败时也会存在并写为 `[]`。
- **force 路径**（`workflow_dispatch` + `mode=force` / `python maintain.py force`）：从原先误写到仓库根目录，改为正确落到 `cache/collect_failures.json`，与 workflow 白名单一致。
- **读取端**：`maintain.py` 用 `if failures:` 判断，空列表自然为 False，行为零变化。
- **API/前端/测试**：无任何调用面变动。

## 验证

- 静态：`collector.py`、`maintain.py` 在 IDE 诊断中均为 0 issue。
- 单测：本地 `pytest tests/ -v` → **38 passed in ~5s**，无 `failed/error/exception`。
- 逻辑用例推演：
- `failures=[]` → 写出 `[]`、不打印告警、`add-paths` 命中。
- `failures=[{...}]` → 写出明细、打印 `[!] N conference(s) failed.`、`add-paths` 命中。
- `cache_file=None`（force） → 路径仍为 `cache/collect_failures.json`，不再污染仓库根目录。

## 兼容性 / 风险

- 不引入新依赖。
- 不修改 workflow yaml，无需重新审阅权限/secrets。
- 仓库会新增一个常态为 `[]` 的小 JSON 文件作为采集状态的一部分，与 `cache/collect_progress.json`、`cache/readme_meta.json` 同源同语义。

## Related

- Failed run: actions/runs/28311776430
- Affected files: `collector.py`, `maintain.py`
- Touched workflow contract (not modified): `.github/workflows/collect_papers.yml` 的 `AUTO_COLLECT_FILES` / `add-paths`