### PR TITLE
Fix/cache cleanup review followup

### DIFF
--- a/scripts/cleanup_cache_dedupe.py
+++ b/scripts/cleanup_cache_dedupe.py
@@ -39,7 +39,7 @@
 退出码
 ------
     0 成功
-    1 输入校验失败（cache 缺失 / 解析异常超过阈值）
+    1 输入校验失败（cache 缺失 / 解析异常占比超过 --max-parse-error-ratio）
     2 写入后回读校验失败（已回滚，原文件未变）
 """
 
@@ -61,7 +61,11 @@ from collector import _merge_paper_record  # noqa: E402
 DEFAULT_CACHE = ROOT / "cache" / "cache.jsonl.gz"
 
 
-def _pid_of(rec: dict) -> str:
+class ParseErrorThresholdExceeded(RuntimeError):
+    """解析错误占比超过阈值：契约上 main() 应以 exit code 1 退出。"""
+
+
+def _pid_of(rec: dict) -> "str | None":
     """计算一条 record 的内部去重桶键。
 
     与 collector._merge_with_cache 的去重语义对齐——按 (conf, paper_url)
@@ -70,8 +74,18 @@ def _pid_of(rec: dict) -> str:
     paper_url 为空时按 (conf, paper_name_lower) 兜底，这是相对 collector
     更严的偏离（collector 对空 url 直接 append 不去重），仅用于清掉历史
     无 URL 的脏重复；conf 同时参与桶键，不会把不同会议下的同名论文错合。
+
+    若 ``rec`` 的 ``conf`` 字段缺失、为空或不是 ``str`` 类型，返回 ``None``
+    表示「拒绝参与任何跨记录合并」——调用方应把这种行直接放到一个唯一桶里
+    （用 ``id(rec)`` 之类的唯一键），避免跨会议同 URL 在 conf 字段缺失时被
+    `_merge_paper_record` 无声地字段级合并、产生不可逆的数据污染。
     """
-    conf = (rec.get("conf") or "").strip()
+    conf_raw = rec.get("conf")
+    if not isinstance(conf_raw, str):
+        return None
+    conf = conf_raw.strip()
+    if not conf:
+        return None
     url = (rec.get("paper_url") or "").strip()
     if url:
         key = f"{conf}|url|{url}"
@@ -87,17 +101,25 @@ def cleanup(
     dry_run: bool = False,
     backup: bool = True,
     report_path: Path | None = None,
+    max_parse_error_ratio: float = 0.0,
 ) -> dict:
-    """读取 ``source``、去重、（除非 dry-run）写回 ``source``，返回统计字典。"""
+    """读取 ``source``、去重、（除非 dry-run）写回 ``source``，返回统计字典。
+
+    ``max_parse_error_ratio`` 控制坏行容忍度：若 ``parse_errors / total_lines``
+    严格大于该比例，则抛 ``RuntimeError`` 并拒绝写回（dry-run 模式也会抛）。
+    默认 ``0.0`` —— 任何一条 JSON 解析失败都视为契约违反，避免坏行被全量
+    重写后静默丢失。设 ``1.0`` 可显式关闭该检查（不推荐）。
+    """
 
     if not source.exists():
         raise FileNotFoundError(f"cache file not found: {source}")
 
-    pid_to_record: "dict[str, dict]" = {}
-    order: "list[str]" = []  # 保留首次出现顺序，输出更稳定
+    pid_to_record: "dict[object, dict]" = {}
+    order: "list[object]" = []  # 保留首次出现顺序，输出更稳定
     total = 0
     parse_errors = 0
     merge_events = 0
+    skipped_no_conf = 0  # conf 缺失/类型异常，直接放唯一桶不参与合并
     abstract_rescued = 0  # 原 record abstract 为空、合并后非空
     abstract_upgraded = 0  # 原 record abstract 非空但被换成更长的
     code_upgraded = 0  # 原 record code 是 '#' 或空、被换成真实链接
@@ -113,7 +135,15 @@ def cleanup(
                 parse_errors += 1
                 continue
             total += 1
-            pid = _pid_of(rec)
+            pid = _pid_of(rec) if isinstance(rec, dict) else None
+            if pid is None:
+                # conf 缺失或 rec 不是 dict —— 用对象身份做桶键，保证唯一、
+                # 不会与任何其他记录合并；这条记录会按首次出现顺序原样写回。
+                unique_key = ("__no_conf__", id(rec))
+                pid_to_record[unique_key] = rec
+                order.append(unique_key)
+                skipped_no_conf += 1
+                continue
             prior = pid_to_record.get(pid)
             if prior is None:
                 pid_to_record[pid] = rec
@@ -153,6 +183,7 @@ def cleanup(
         "unique_pids": unique,
         "rows_saved": rows_saved,
         "merge_events": merge_events,
+        "skipped_no_conf": skipped_no_conf,
         "abstract_rescued": abstract_rescued,
         "abstract_upgraded": abstract_upgraded,
         "code_upgraded": code_upgraded,
@@ -162,6 +193,18 @@ def cleanup(
 
     if report_path is not None:
         _write_report(report_path, stats)
+
+    # 解析错误占比检查：契约上声明 exit code 1。total 与 parse_errors 共同
+    # 构成「曾出现过的行数」分母——空行已经被前面 skip，不计入。
+    denom = total + parse_errors
+    if denom > 0:
+        ratio = parse_errors / denom
+        if ratio > max_parse_error_ratio:
+            raise ParseErrorThresholdExceeded(
+                f"parse_errors ratio {ratio:.4f} exceeds threshold "
+                f"{max_parse_error_ratio:.4f} (parse_errors={parse_errors}, "
+                f"total_rows={total}); refusing to rewrite cache"
+            )
 
     if dry_run:
         return stats
@@ -228,6 +271,12 @@ def main(argv=None) -> int:
                         help="写入时不保留 .bak 备份（不推荐）")
     parser.add_argument("--report", type=Path, default=None,
                         help="把统计结果同时写到该文本文件")
+    parser.add_argument(
+        "--max-parse-error-ratio",
+        type=float,
+        default=0.0,
+        help="允许的 JSON 解析失败行占比，超过则以 exit code 1 终止；默认 0.0",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -236,9 +285,13 @@ def main(argv=None) -> int:
             dry_run=args.dry_run,
             backup=not args.no_backup,
             report_path=args.report,
+            max_parse_error_ratio=args.max_parse_error_ratio,
         )
     except FileNotFoundError as exc:
         print(f"[cleanup_cache_dedupe] ERROR: {exc}", file=sys.stderr)
+        return 1
+    except ParseErrorThresholdExceeded as exc:
+        print(f"[cleanup_cache_dedupe] PARSE ERRORS: {exc}", file=sys.stderr)
         return 1
     except RuntimeError as exc:
         print(f"[cleanup_cache_dedupe] VERIFY FAILED: {exc}", file=sys.stderr)

--- a/tests/test_cleanup_cache_dedupe.py
+++ b/tests/test_cleanup_cache_dedupe.py
@@ -269,3 +269,119 @@ def test_cleanup_writes_report_when_requested(tmp_path):
     text = report.read_text(encoding="utf-8")
     assert "unique_pids: 1" in text
     assert "total_rows: 2" in text
+
+
+# ---------------------------------------------------------------------------
+# 8. Parse-error threshold contract (PR review fix #2)
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_raises_when_parse_errors_exceed_threshold(tmp_path):
+    """坏行存在时，默认阈值 0.0 必须抛 ParseErrorThresholdExceeded。
+
+    回归 PR#94 review #2：模块 docstring 声称「解析异常超过阈值」会以
+    exit 1 终止，但旧实现只累计 parse_errors 不做任何阈值判断，会让
+    坏行被全量重写后静默丢失。
+    """
+    cache = tmp_path / "cache.jsonl.gz"
+    with gzip.open(cache, "wt", encoding="utf-8") as f:
+        f.write(json.dumps({"paper_name": "P", "paper_url": "u1",
+                            "paper_authors": [], "paper_abstract": "",
+                            "paper_code": "#", "conf": "C"}) + "\n")
+        f.write("{not valid json\n")
+    pre_bytes = cache.read_bytes()
+
+    with pytest.raises(cc.ParseErrorThresholdExceeded):
+        cc.cleanup(cache, dry_run=False, backup=False)
+
+    # 原文件未被改写，.tmp / .bak 都不应残留
+    assert cache.read_bytes() == pre_bytes
+    assert not (tmp_path / "cache.jsonl.gz.tmp").exists()
+    assert not (tmp_path / "cache.jsonl.gz.bak").exists()
+
+
+def test_cleanup_allows_parse_errors_when_ratio_relaxed(tmp_path):
+    """显式提高阈值时坏行应被允许丢弃，正常完成清洗。"""
+    cache = tmp_path / "cache.jsonl.gz"
+    with gzip.open(cache, "wt", encoding="utf-8") as f:
+        f.write(json.dumps({"paper_name": "P", "paper_url": "u1",
+                            "paper_authors": [], "paper_abstract": "",
+                            "paper_code": "#", "conf": "C"}) + "\n")
+        f.write("{not valid json\n")
+
+    stats = cc.cleanup(
+        cache, dry_run=False, backup=False, max_parse_error_ratio=1.0
+    )
+    assert stats["parse_errors"] == 1
+    assert stats["total_rows"] == 1
+    assert stats["unique_pids"] == 1
+
+
+def test_main_returns_exit_code_1_on_parse_errors(tmp_path):
+    """CLI 路径同样要遵守契约：解析错误超限以 exit code 1 退出。"""
+    cache = tmp_path / "cache.jsonl.gz"
+    with gzip.open(cache, "wt", encoding="utf-8") as f:
+        f.write("not json at all\n")
+
+    rc = cc.main(["--source", str(cache)])
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# 9. Missing conf field never triggers cross-record merge (PR review fix #3)
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_does_not_merge_records_missing_conf(tmp_path):
+    """两条 conf 缺失但 paper_url 相同的记录绝不能被字段级合并。
+
+    回归 PR#94 review #3：旧实现把缺失的 conf 退化为空串后参与 sha1，
+    导致跨会议同 URL 在 conf 字段缺失时被 `_merge_paper_record` 无声
+    地字段级合并，产生不可逆的数据污染。
+    """
+    cache = tmp_path / "cache.jsonl.gz"
+    records = [
+        # 两条都缺 conf；如果按空串当 conf 参与 hash，会被错合
+        {"paper_name": "X", "paper_url": "https://example.com/p1",
+         "paper_authors": ["A"], "paper_abstract": "abs from source 1",
+         "paper_code": "#"},
+        {"paper_name": "Y different title", "paper_url": "https://example.com/p1",
+         "paper_authors": ["B"], "paper_abstract": "abs from source 2",
+         "paper_code": "https://github.com/x/y"},
+        # conf 不是 str（异常类型）也不应参与合并
+        {"paper_name": "Z", "paper_url": "https://example.com/p1",
+         "paper_authors": ["C"], "paper_abstract": "abs from source 3",
+         "paper_code": "#", "conf": 12345},
+    ]
+    _write_jsonl_gz(cache, records)
+
+    stats = cc.cleanup(cache, dry_run=False, backup=False)
+    rows = _read_jsonl_gz(cache)
+
+    assert stats["skipped_no_conf"] == 3
+    assert stats["merge_events"] == 0
+    assert len(rows) == 3
+    # 字段不能交叉污染
+    abstracts = sorted(r["paper_abstract"] for r in rows)
+    assert abstracts == ["abs from source 1", "abs from source 2", "abs from source 3"]
+    authors_sets = sorted([r["paper_authors"] for r in rows], key=str)
+    assert authors_sets == [["A"], ["B"], ["C"]]
+
+
+def test_cleanup_still_merges_when_conf_present(tmp_path):
+    """有 conf 时仍要正常合并——确认 #3 修复没有破坏正常路径。"""
+    cache = tmp_path / "cache.jsonl.gz"
+    records = [
+        {"paper_name": "P", "paper_url": "u1", "paper_authors": [],
+         "paper_abstract": "", "paper_code": "#", "conf": "ICLR2026"},
+        {"paper_name": "P", "paper_url": "u1", "paper_authors": ["A"],
+         "paper_abstract": "long abs", "paper_code": "#", "conf": "ICLR2026"},
+    ]
+    _write_jsonl_gz(cache, records)
+
+    stats = cc.cleanup(cache, dry_run=False, backup=False)
+    rows = _read_jsonl_gz(cache)
+    assert stats["skipped_no_conf"] == 0
+    assert stats["merge_events"] == 1
+    assert len(rows) == 1
+    assert rows[0]["paper_abstract"] == "long abs"


### PR DESCRIPTION
PR #94  (Fix/cache cleanup) 已合入 main，review 复盘发现两处可触发数据风险的契约缺口，本 PR 仅做修复，不改动 PR #94  已有的正常路径行为。

## Fixes
- **parse_errors 静默吞异常**：模块 docstring 声称解析异常超过阈值会以 exit code 1 终止，旧实现没有任何阈值判断；引入 `ParseErrorThresholdExceeded` 与 `--max-parse-error-ratio`，默认 `0.0`。
- **conf 缺失导致跨会议错合**：`_pid_of` 在 `conf` 缺失或非 str 时返回 `None`，调用方把这些行路由到唯一桶并计入 `stats["skipped_no_conf"]`。

## Tests
- 新增 5 个用例（阈值默认/放宽、CLI 退出码、缺 conf 不合并、conf 正常仍合并）
- `pytest tests/test_cleanup_cache_dedupe.py` → 13 passed
- `pytest`（全仓库） → 55 passed