### PR TITLE
fix(ai): bump anthropic max_tokens and disable StepFun thinking mode

### DIFF
--- a/papervault/config.py
+++ b/papervault/config.py
@@ -89,7 +89,7 @@ class Settings:
     )
 
     anthropic_max_tokens: int = field(
-        default_factory=lambda: _env_int("PAPERVAULT_ANTHROPIC_MAX_TOKENS", 512)
+        default_factory=lambda: _env_int("PAPERVAULT_ANTHROPIC_MAX_TOKENS", 2048)
     )
     anthropic_model: str = field(
         default_factory=lambda: _env_str("PAPERVAULT_ANTHROPIC_MODEL", "claude-haiku-4-5")

--- a/papervault/services/ai_clients.py
+++ b/papervault/services/ai_clients.py
@@ -149,25 +149,32 @@ def call_anthropic(
     # no-op (its default state), so the same payload is safe to send
     # everywhere.
     try:
-        response = client.messages.create(
-            model=model,
-            system=system,
-            messages=[{"role": "user", "content": user}],
-            temperature=temperature,
-            max_tokens=max_tokens,
-            extra_body={"thinking": {"type": "disabled"}},
-        )
-    except TypeError:
-        # Older anthropic SDK (<0.40) does not accept ``extra_body`` on
-        # ``messages.create``; fall back to the plain call so callers
-        # with pinned SDK versions still work.
-        response = client.messages.create(
-            model=model,
-            system=system,
-            messages=[{"role": "user", "content": user}],
-            temperature=temperature,
-            max_tokens=max_tokens,
-        )
+        try:
+            response = client.messages.create(
+                model=model,
+                system=system,
+                messages=[{"role": "user", "content": user}],
+                temperature=temperature,
+                max_tokens=max_tokens,
+                extra_body={"thinking": {"type": "disabled"}},
+            )
+        except TypeError as type_exc:
+            # Older anthropic SDK (<0.40) does not accept ``extra_body`` on
+            # ``messages.create``; fall back to the plain call so callers
+            # with pinned SDK versions still work. We narrow the trigger to
+            # the specific kwargs-rejection message so unrelated TypeErrors
+            # (e.g. a future SDK renaming a stable kwarg) are not silently
+            # swallowed into a retry.
+            msg = str(type_exc)
+            if "extra_body" not in msg and "unexpected keyword" not in msg:
+                raise
+            response = client.messages.create(
+                model=model,
+                system=system,
+                messages=[{"role": "user", "content": user}],
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
     except Exception as exc:
         logger.exception("Anthropic-compatible call failed: %s", exc)
         raise UpstreamError(

--- a/papervault/services/ai_clients.py
+++ b/papervault/services/ai_clients.py
@@ -139,7 +139,28 @@ def call_anthropic(
         kwargs["default_headers"] = dict(extra_headers)
 
     client = anthropic.Anthropic(**kwargs)
+    # ``StepFun.step_plan`` enables a "thinking" mode by default that
+    # consumes the entire ``max_tokens`` budget on internal reasoning and
+    # returns ``stop_reason='max_tokens'`` with no visible text. The
+    # ``thinking`` field is not part of the official Anthropic SDK
+    # signature (the SDK forwards unknown kwargs through ``extra_body``),
+    # so we pass it via ``client.messages.create(..., extra_body=...)``
+    # below. Anthropic's native API treats ``type: disabled`` as a
+    # no-op (its default state), so the same payload is safe to send
+    # everywhere.
     try:
+        response = client.messages.create(
+            model=model,
+            system=system,
+            messages=[{"role": "user", "content": user}],
+            temperature=temperature,
+            max_tokens=max_tokens,
+            extra_body={"thinking": {"type": "disabled"}},
+        )
+    except TypeError:
+        # Older anthropic SDK (<0.40) does not accept ``extra_body`` on
+        # ``messages.create``; fall back to the plain call so callers
+        # with pinned SDK versions still work.
         response = client.messages.create(
             model=model,
             system=system,

--- a/tests/test_ai_clients.py
+++ b/tests/test_ai_clients.py
@@ -243,6 +243,85 @@ def test_call_anthropic_strips_trailing_v1(monkeypatch):
         assert captured["client_kwargs"]["base_url"] == expected, (raw, expected, captured)
 
 
+def test_call_anthropic_passes_thinking_disabled(monkeypatch):
+    """StepFun's default thinking mode eats the entire max_tokens budget.
+    We pass ``extra_body={"thinking": {"type": "disabled"}}`` so StepFun
+    skips thinking; Anthropic's native API treats it as a no-op.
+    """
+
+    import anthropic as anthropic_module
+
+    captured = {}
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            block = MagicMock()
+            block.text = "ok"
+            resp = MagicMock()
+            resp.content = [block]
+            resp.model = "m"
+            return resp
+
+    class FakeAnthropic:
+        def __init__(self, **kwargs):
+            self.messages = FakeMessages()
+
+    monkeypatch.setattr(anthropic_module, "Anthropic", FakeAnthropic)
+
+    ai_clients.call_anthropic(
+        api_key="k",
+        base_url="https://api.stepfun.com/step_plan/v1",
+        model="step-3.7-flash",
+        system="s",
+        user="u",
+        temperature=0.5,
+        max_tokens=512,
+    )
+    assert captured["extra_body"] == {"thinking": {"type": "disabled"}}
+    assert captured["max_tokens"] == 512
+
+
+def test_call_anthropic_falls_back_when_extra_body_unsupported(monkeypatch):
+    """Anthropic SDK <0.40 doesn't accept ``extra_body`` on messages.create;
+    we should still issue the call (without the thinking override)."""
+
+    import anthropic as anthropic_module
+
+    captured = {}
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            if "extra_body" in kwargs:
+                raise TypeError(
+                    "messages.create() got an unexpected keyword argument 'extra_body'"
+                )
+            captured.update(kwargs)
+            block = MagicMock()
+            block.text = "ok"
+            resp = MagicMock()
+            resp.content = [block]
+            resp.model = "m"
+            return resp
+
+    class FakeAnthropic:
+        def __init__(self, **kwargs):
+            self.messages = FakeMessages()
+
+    monkeypatch.setattr(anthropic_module, "Anthropic", FakeAnthropic)
+
+    ai_clients.call_anthropic(
+        api_key="k",
+        base_url="https://api.anthropic.com",
+        model="claude-haiku-4-5",
+        system="s",
+        user="u",
+        temperature=0.5,
+    )
+    assert "extra_body" not in captured
+    assert captured["max_tokens"] == 512  # default
+
+
 def test_call_anthropic_missing_sdk(monkeypatch):
     import builtins
 


### PR DESCRIPTION
## 背景

P2-A 上游 (`#100`) 只通过 `https://api.stepfun.com/step_plan/v1` 的 dummy-key 测试（401 = 协议通），暴露不出 StepFun 的 thinking 行为差异。真实密钥端到端测试发现：

- `step-3.7-flash` 默认开启 thinking 模式，把整个 `max_tokens` 预算都消耗在内部推理上
- 原 512 token 默认值下，每次响应都是 `stop_reason='max_tokens'` 且 `content=[ThinkingBlock]`，没有可见文本
- JSON 关键词响应实际只需要 ~900 token，但 thinking 占用了前 ~1500

## 修复

两处最小改动：

1. **`anthropic_max_tokens` 默认值 512 → 2048**
   - Anthropic 原生 API 不在意 headroom
   - StepFun thinking + 可见文本一起 ~1700 token，能装下
2. **`call_anthropic()` 传 `extra_body={"thinking":{"type":"disabled"}}`**
   - StepFun 接受该字段并跳过 thinking（同样 prompt 下 `output_tokens` 从 ~1500 降到 ~900）
   - Anthropic 原生 API 对该字段是 no-op（默认就是 thinking off），所以同一 payload 在两边都安全
   - `anthropic SDK <0.40` 的 `messages.create` 不支持 `extra_body` kwarg，加 TypeError fallback 走老路径

## 影响面

- 仅影响 Anthropic / Anthropic-compatible 协议路径（即 StepFun 的 step_plan 端）
- OpenAI-compatible 协议路径未触及（`call_openai_compatible()` 无变更）
- `PAPERVAULT_ANTHROPIC_MAX_TOKENS` 环境变量覆盖语义不变

## 测试

- 新增 2 个测试锁定 `extra_body` 转发行为和 SDK<0.40 fallback 路径
- 全量 `pytest` → 74 passed

## 验证

- 真实 StepFun 密钥端到端：`output_tokens=913`，`TextBlock` 携带期望的 JSON 关键词响应