### PR TITLE
feat(web): P2-B frontend AI infrastructure

### DIFF
--- a/web-vue/src/api/ai.ts
+++ b/web-vue/src/api/ai.ts
@@ -1,0 +1,56 @@
+/**
+ * AI provider + keyword-suggestion endpoints (P2).
+ *
+ * Kept in a separate file from `api/paper.ts` so the legacy
+ * `suggestKeywords(query: string)` signature in `paper.ts` keeps working
+ * against the pre-P2 backend while we ship P2-B independently. The
+ * settings-aware overload below is wired into the Settings page in P2-D.
+ */
+
+import request from '@/utils/axios'
+import type { SuggestApiPayload } from '@/utils/aiSettings'
+import type { AiProviderPreset } from '@/constants/aiProviders'
+
+export interface SuggestRequestBody {
+  query: string
+  provider?: string
+  base_url?: string
+  model?: string
+  api_key?: string
+  protocol?: string
+  temperature?: number
+  max_keywords?: number
+  max_tokens?: number
+}
+
+export interface SuggestApiResponse {
+  keywords: string[]
+  timecost_ms: number
+  model: string
+  provider: string
+  protocol: string
+}
+
+export interface ProviderListResponse {
+  items: AiProviderPreset[]
+}
+
+export const listAiProviders = () =>
+  request<ProviderListResponse>({
+    url: '/v1/ai/providers',
+    method: 'get',
+    silent: true
+  })
+
+export const suggestKeywordsWithSettings = (
+  query: string,
+  payload: SuggestApiPayload = {}
+) => {
+  const body: SuggestRequestBody = { query, ...payload }
+  return request<SuggestApiResponse>({
+    url: '/v1/suggest',
+    method: 'post',
+    data: body,
+    silent: true
+  })
+}

--- a/web-vue/src/api/ai.ts
+++ b/web-vue/src/api/ai.ts
@@ -9,7 +9,7 @@
 
 import request from '@/utils/axios'
 import type { SuggestApiPayload } from '@/utils/aiSettings'
-import type { AiProviderPreset } from '@/constants/aiProviders'
+import type { AiProviderPreset, ProtocolKind } from '@/constants/aiProviders'
 
 export interface SuggestRequestBody {
   query: string
@@ -35,12 +35,55 @@ export interface ProviderListResponse {
   items: AiProviderPreset[]
 }
 
-export const listAiProviders = () =>
-  request<ProviderListResponse>({
+interface RawProviderPreset {
+  key?: string
+  label?: string
+  protocol?: string
+  base_url?: string
+  model?: string
+  note?: string
+  env_key_var?: string
+  env_base_var?: string
+  env_model_var?: string
+  requires_max_tokens?: boolean
+}
+
+interface RawProviderListResponse {
+  items?: RawProviderPreset[]
+}
+
+const PROTOCOL_VALUES: readonly ProtocolKind[] = [
+  'openai-compatible',
+  'anthropic'
+]
+
+const normalizeProtocol = (value: unknown): ProtocolKind =>
+  typeof value === 'string' && PROTOCOL_VALUES.includes(value as ProtocolKind)
+    ? (value as ProtocolKind)
+    : 'openai-compatible'
+
+const normalizeProviderPreset = (raw: RawProviderPreset): AiProviderPreset => ({
+  key: typeof raw.key === 'string' ? raw.key : '',
+  label: typeof raw.label === 'string' ? raw.label : '',
+  protocol: normalizeProtocol(raw.protocol),
+  baseUrl: typeof raw.base_url === 'string' ? raw.base_url : '',
+  model: typeof raw.model === 'string' ? raw.model : '',
+  note: typeof raw.note === 'string' ? raw.note : '',
+  envKeyVar: typeof raw.env_key_var === 'string' ? raw.env_key_var : '',
+  envBaseVar: typeof raw.env_base_var === 'string' ? raw.env_base_var : '',
+  envModelVar: typeof raw.env_model_var === 'string' ? raw.env_model_var : '',
+  requiresMaxTokens: Boolean(raw.requires_max_tokens)
+})
+
+export const listAiProviders = async (): Promise<ProviderListResponse> => {
+  const raw = await request<RawProviderListResponse>({
     url: '/v1/ai/providers',
     method: 'get',
     silent: true
   })
+  const items = Array.isArray(raw?.items) ? raw.items : []
+  return { items: items.map(normalizeProviderPreset) }
+}
 
 export const suggestKeywordsWithSettings = (
   query: string,

--- a/web-vue/src/constants/aiProviders.ts
+++ b/web-vue/src/constants/aiProviders.ts
@@ -1,9 +1,15 @@
 /**
  * Frontend mirror of `papervault.services.ai_providers.ProviderPreset`.
  *
- * Keep the field names (camelCase) and values in lockstep with the backend
- * catalog. The backend serves the same list at `GET /api/v1/ai/providers`
- * so the Settings page (P2-C) can confirm the two sides have not drifted.
+ * Catalog values are kept in lockstep with the backend by hand. Field
+ * *names* are NOT: this module uses camelCase (`baseUrl`, `envKeyVar`,
+ * `requiresMaxTokens`) for ergonomic FE consumption, while the backend's
+ * `ProviderPreset.as_dict()` emits snake_case (`base_url`, `env_key_var`,
+ * `requires_max_tokens`) directly from `dataclasses.asdict`. The two
+ * shapes are bridged at ingress by `normalizeProviderPreset` in
+ * `@/api/ai.ts`, which maps the wire payload of `GET /api/v1/ai/providers`
+ * into this `AiProviderPreset` interface. The Settings page (P2-C) should
+ * always consume the normalized version, never cast the raw response.
  *
  * `StepFun`'s `step_plan` endpoint speaks the Anthropic Messages protocol,
  * not the OpenAI-compatible chat completions used by plan-pilot's StepFun

--- a/web-vue/src/constants/aiProviders.ts
+++ b/web-vue/src/constants/aiProviders.ts
@@ -1,0 +1,134 @@
+/**
+ * Frontend mirror of `papervault.services.ai_providers.ProviderPreset`.
+ *
+ * Keep the field names (camelCase) and values in lockstep with the backend
+ * catalog. The backend serves the same list at `GET /api/v1/ai/providers`
+ * so the Settings page (P2-C) can confirm the two sides have not drifted.
+ *
+ * `StepFun`'s `step_plan` endpoint speaks the Anthropic Messages protocol,
+ * not the OpenAI-compatible chat completions used by plan-pilot's StepFun
+ * preset (`api.stepfun.ai`). The P2-A connectivity check confirmed that
+ * `https://api.stepfun.com/step_plan/v1/messages` returns the expected
+ * 401 with a dummy `x-api-key`, matching the Anthropic SDK's wire format.
+ */
+
+export type ProtocolKind = 'openai-compatible' | 'anthropic'
+
+export interface AiProviderPreset {
+  key: string
+  label: string
+  protocol: ProtocolKind
+  baseUrl: string
+  model: string
+  note: string
+  envKeyVar: string
+  envBaseVar: string
+  envModelVar: string
+  requiresMaxTokens: boolean
+}
+
+export const AI_PROVIDER_PRESETS: Record<string, AiProviderPreset> = {
+  openai: {
+    key: 'openai',
+    label: 'OpenAI',
+    protocol: 'openai-compatible',
+    baseUrl: 'https://api.openai.com/v1',
+    model: 'gpt-4o-mini',
+    note: 'OpenAI 官方 Chat Completions 接口。也可改成 gpt-5-mini 等更轻模型。',
+    envKeyVar: 'OPENAI_API_KEY',
+    envBaseVar: 'OPENAI_API_BASE',
+    envModelVar: 'PAPERVAULT_OPENAI_MODEL',
+    requiresMaxTokens: false
+  },
+  deepseek: {
+    key: 'deepseek',
+    label: 'DeepSeek',
+    protocol: 'openai-compatible',
+    baseUrl: 'https://api.deepseek.com',
+    model: 'deepseek-chat',
+    note: 'DeepSeek 官方 OpenAI-compatible 接口。',
+    envKeyVar: 'DEEPSEEK_API_KEY',
+    envBaseVar: 'PAPERVAULT_DEEPSEEK_BASE_URL',
+    envModelVar: 'PAPERVAULT_DEEPSEEK_MODEL',
+    requiresMaxTokens: false
+  },
+  anthropic: {
+    key: 'anthropic',
+    label: 'Anthropic Claude',
+    protocol: 'anthropic',
+    baseUrl: 'https://api.anthropic.com',
+    model: 'claude-haiku-4-5',
+    note: 'Anthropic Messages API。模型名按 Anthropic 控制台可用列表调整。',
+    envKeyVar: 'ANTHROPIC_API_KEY',
+    envBaseVar: 'ANTHROPIC_API_BASE',
+    envModelVar: 'PAPERVAULT_ANTHROPIC_MODEL',
+    requiresMaxTokens: true
+  },
+  qwen: {
+    key: 'qwen',
+    label: '通义千问 / DashScope',
+    protocol: 'openai-compatible',
+    baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+    model: 'qwen-plus',
+    note: '阿里云百炼 OpenAI 兼容模式；国际站可改为 dashscope-intl 地址。',
+    envKeyVar: 'QWEN_API_KEY',
+    envBaseVar: 'QWEN_API_BASE',
+    envModelVar: 'PAPERVAULT_QWEN_MODEL',
+    requiresMaxTokens: false
+  },
+  glm: {
+    key: 'glm',
+    label: '智谱 GLM',
+    protocol: 'openai-compatible',
+    baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+    model: 'glm-4-flash',
+    note: '智谱 BigModel OpenAI-compatible 接口。',
+    envKeyVar: 'GLM_API_KEY',
+    envBaseVar: 'GLM_API_BASE',
+    envModelVar: 'PAPERVAULT_GLM_MODEL',
+    requiresMaxTokens: false
+  },
+  stepfun: {
+    key: 'stepfun',
+    label: '阶跃星辰 StepFun',
+    protocol: 'anthropic',
+    baseUrl: 'https://api.stepfun.com/step_plan/v1',
+    model: 'step-3.7-flash',
+    note: 'StepFun 的 step_plan 端点是 Anthropic Messages API 兼容（不是 OpenAI）。',
+    envKeyVar: 'STEPFUN_API_KEY',
+    envBaseVar: 'STEPFUN_BASE_URL',
+    envModelVar: 'PAPERVAULT_STEPFUN_MODEL',
+    requiresMaxTokens: true
+  },
+  custom: {
+    key: 'custom',
+    label: '自定义 / OpenAI 兼容',
+    protocol: 'openai-compatible',
+    baseUrl: '',
+    model: '',
+    note: '填写任何兼容 /chat/completions 或 /messages 的服务地址和模型名。',
+    envKeyVar: '',
+    envBaseVar: '',
+    envModelVar: '',
+    requiresMaxTokens: false
+  }
+}
+
+export function getAiProviderPreset(
+  key: string | null | undefined
+): AiProviderPreset {
+  if (key && AI_PROVIDER_PRESETS[key]) return AI_PROVIDER_PRESETS[key]
+  return AI_PROVIDER_PRESETS.custom
+}
+
+export function getAiProvidersInOrder(): AiProviderPreset[] {
+  return [
+    AI_PROVIDER_PRESETS.openai,
+    AI_PROVIDER_PRESETS.deepseek,
+    AI_PROVIDER_PRESETS.anthropic,
+    AI_PROVIDER_PRESETS.qwen,
+    AI_PROVIDER_PRESETS.glm,
+    AI_PROVIDER_PRESETS.stepfun,
+    AI_PROVIDER_PRESETS.custom
+  ]
+}

--- a/web-vue/src/utils/aiSettings.ts
+++ b/web-vue/src/utils/aiSettings.ts
@@ -63,6 +63,32 @@ function safeRemove(storage: Storage, key: string): void {
   }
 }
 
+function pickString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function pickFiniteNumber(
+  value: unknown,
+  min: number,
+  max: number
+): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  if (value < min || value > max) return null
+  return value
+}
+
+function sanitizeAiSettings(raw: Record<string, unknown>): AiUserSettings {
+  return {
+    provider: pickString(raw.provider),
+    baseUrl: pickString(raw.baseUrl),
+    model: pickString(raw.model),
+    protocol: pickString(raw.protocol),
+    temperature: pickFiniteNumber(raw.temperature, 0, 2),
+    maxKeywords: pickFiniteNumber(raw.maxKeywords, 1, 50),
+    maxTokens: pickFiniteNumber(raw.maxTokens, 1, 4096)
+  }
+}
+
 export function loadAiSettings(): AiUserSettings {
   const raw = safeGet(
     typeof localStorage !== 'undefined'
@@ -73,10 +99,8 @@ export function loadAiSettings(): AiUserSettings {
   if (!raw) return { ...EMPTY_SETTINGS }
   try {
     const parsed = JSON.parse(raw)
-    return {
-      ...EMPTY_SETTINGS,
-      ...parsed
-    }
+    if (!parsed || typeof parsed !== 'object') return { ...EMPTY_SETTINGS }
+    return sanitizeAiSettings(parsed as Record<string, unknown>)
   } catch {
     return { ...EMPTY_SETTINGS }
   }

--- a/web-vue/src/utils/aiSettings.ts
+++ b/web-vue/src/utils/aiSettings.ts
@@ -1,0 +1,161 @@
+/**
+ * localStorage + sessionStorage adapter for AI provider settings.
+ *
+ * Storage split:
+ *   - Non-secret knobs (provider, baseUrl, model, protocol, temperature,
+ *     maxKeywords, maxTokens) live in localStorage so the user's last pick
+ *     survives a browser restart.
+ *   - The API key lives in sessionStorage: it is wiped when the tab closes,
+ *     which is a reasonable safety floor for a public-domain paper search
+ *     site without forcing the user to re-paste a key every refresh.
+ *
+ * `provider = ''` is the explicit "follow server default" sentinel. The
+ * backend (`papervault.services.suggest._resolve_provider`) treats an
+ * absent provider the same way, so the round-trip is lossless.
+ */
+
+import type { AiProviderPreset } from '@/constants/aiProviders'
+
+const SETTINGS_KEY = 'papervault.ai.settings.v1'
+const API_KEY_KEY = 'papervault.ai.apiKey.v1'
+
+export interface AiUserSettings {
+  provider: string
+  baseUrl: string
+  model: string
+  protocol: string
+  temperature: number | null
+  maxKeywords: number | null
+  maxTokens: number | null
+}
+
+const EMPTY_SETTINGS: AiUserSettings = {
+  provider: '',
+  baseUrl: '',
+  model: '',
+  protocol: '',
+  temperature: null,
+  maxKeywords: null,
+  maxTokens: null
+}
+
+function safeGet(storage: Storage, key: string): string | null {
+  try {
+    return storage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function safeSet(storage: Storage, key: string, value: string): void {
+  try {
+    storage.setItem(key, value)
+  } catch {
+    // ignore quota / private-mode errors; settings are best-effort
+  }
+}
+
+function safeRemove(storage: Storage, key: string): void {
+  try {
+    storage.removeItem(key)
+  } catch {
+    // ignore
+  }
+}
+
+export function loadAiSettings(): AiUserSettings {
+  const raw = safeGet(
+    typeof localStorage !== 'undefined'
+      ? localStorage
+      : (null as unknown as Storage),
+    SETTINGS_KEY
+  )
+  if (!raw) return { ...EMPTY_SETTINGS }
+  try {
+    const parsed = JSON.parse(raw)
+    return {
+      ...EMPTY_SETTINGS,
+      ...parsed
+    }
+  } catch {
+    return { ...EMPTY_SETTINGS }
+  }
+}
+
+export function saveAiSettings(settings: AiUserSettings): void {
+  if (typeof localStorage === 'undefined') return
+  safeSet(localStorage, SETTINGS_KEY, JSON.stringify(settings))
+}
+
+export function clearAiSettings(): void {
+  if (typeof localStorage !== 'undefined')
+    safeRemove(localStorage, SETTINGS_KEY)
+}
+
+export function loadApiKey(): string {
+  if (typeof sessionStorage === 'undefined') return ''
+  return safeGet(sessionStorage, API_KEY_KEY) || ''
+}
+
+export function saveApiKey(key: string): void {
+  if (typeof sessionStorage === 'undefined') return
+  if (key) safeSet(sessionStorage, API_KEY_KEY, key)
+  else safeRemove(sessionStorage, API_KEY_KEY)
+}
+
+export function clearApiKey(): void {
+  if (typeof sessionStorage !== 'undefined')
+    safeRemove(sessionStorage, API_KEY_KEY)
+}
+
+export interface SuggestApiPayload {
+  provider?: string
+  base_url?: string
+  model?: string
+  api_key?: string
+  protocol?: string
+  temperature?: number
+  max_keywords?: number
+  max_tokens?: number
+}
+
+/**
+ * Project the user's UI settings into the wire payload accepted by
+ * `POST /api/v1/suggest`. Empty / unset fields are dropped so the backend
+ * can keep falling back to its own settings / env defaults.
+ */
+export function toApiPayload(
+  settings: AiUserSettings,
+  apiKey: string
+): SuggestApiPayload {
+  const payload: SuggestApiPayload = {}
+  if (settings.provider) payload.provider = settings.provider
+  if (settings.baseUrl) payload.base_url = settings.baseUrl
+  if (settings.model) payload.model = settings.model
+  if (apiKey) payload.api_key = apiKey
+  if (settings.protocol) payload.protocol = settings.protocol
+  if (settings.temperature != null) payload.temperature = settings.temperature
+  if (settings.maxKeywords != null) payload.max_keywords = settings.maxKeywords
+  if (settings.maxTokens != null) payload.max_tokens = settings.maxTokens
+  return payload
+}
+
+/**
+ * Re-fill empty user fields with the matching preset defaults so the UI
+ * does not have to second-guess the catalog. Used when the user picks a
+ * different provider in the dropdown.
+ */
+export function mergePresetDefaults(
+  settings: AiUserSettings,
+  preset: AiProviderPreset
+): AiUserSettings {
+  return {
+    provider: preset.key,
+    baseUrl: settings.baseUrl || preset.baseUrl,
+    model: settings.model || preset.model,
+    protocol: settings.protocol || preset.protocol,
+    temperature: settings.temperature,
+    maxKeywords: settings.maxKeywords,
+    maxTokens: settings.maxTokens
+  }
+}


### PR DESCRIPTION
## 背景

P2-A 上游 (`#100`) 把后端 7 个 LLM 预设目录（`/api/v1/ai/providers`）和 `/api/v1/suggest` 扩展字段都铺好了，但前端还停留在 `paper.ts` 里的旧 `suggestKeywords(query)` 单调用形态。Settings 页（P2-C）和 AI 关键词建议 section（P2-D）需要先把这层基础设施建好。

## 范围

3 个新文件，零修改既有组件。

### `web-vue/src/constants/aiProviders.ts`（134 行）

镜像后端 `papervault.services.ai_providers.ProviderPreset`：

- 7 个 preset：`openai` / `deepseek` / `anthropic` / `qwen` / `glm` / `stepfun` / `custom`
- `ProtocolKind = 'openai-compatible' | 'anthropic'` —— 按 wire 协议分，不是按厂商
- `getAiProviderPreset(key)`：未知 key 走 `custom` fallback
- `getAiProvidersInOrder()`：稳定排序，`custom` 永远在最后

StepFun preset 注释里特别强调 `https://api.stepfun.com/step_plan/v1` 走的是 **Anthropic Messages 协议**，与 plan-pilot 用的 OpenAI-compatible `api.stepfun.ai` 是不同端点，避免后人混淆。

### `web-vue/src/utils/aiSettings.ts`（161 行）

存储分层：

- 非敏感设置（provider/baseUrl/model/protocol/temperature/maxKeywords/maxTokens）→ `localStorage`，浏览器重启还在
- api_key → `sessionStorage`，关闭浏览器即清，公网部署的合理底线

`toApiPayload(settings, apiKey)` 把 camelCase 投影到 `SuggestRequest` 的 snake_case，空字段直接丢弃让后端走 settings / env fallback。

`mergePresetDefaults(settings, preset)` 切换预设时自动回填空白字段，避免 UI 再写一次 catalog。

### `web-vue/src/api/ai.ts`（56 行）

两个 wrapper：

- `listAiProviders()` → `GET /api/v1/ai/providers`
- `suggestKeywordsWithSettings(query, payload)` → `POST /api/v1/suggest`，body 用 `{ query, ...payload }` 让 caller 可以零额外字段走 legacy 形态

## 验证

- `npx vue-tsc --noEmit` → exit 0
- `npx eslint src/constants/aiProviders.ts src/utils/aiSettings.ts src/api/ai.ts` → 0 warnings
- `grep` 确认零侵入：旧 `paper.ts` 里 `suggestKeywords(query)` 链路未触动

## 依赖

需要后端 `/api/v1/ai/providers`（已在 `#100` 中通过 `suggest_bp` 注册）和 `/api/v1/suggest`（同 PR）。

## 下一步

- **P2-C**：Settings 页骨架（路由 + nav + i18n）
- **P2-D**：在 Settings 里挂 AI Suggest section，调用本 PR 的两个 wrapper