### PR TITLE
feat(web): P2-C settings page shell + shared MainNavBar

### DIFF
--- a/web-vue/components.d.ts
+++ b/web-vue/components.d.ts
@@ -8,6 +8,7 @@ export {}
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
     ConfsTree: typeof import('./src/components/ConfsTree.vue')['default']
+    ElAlert: typeof import('element-plus/es')['ElAlert']
     ElBacktop: typeof import('element-plus/es')['ElBacktop']
     ElButton: typeof import('element-plus/es')['ElButton']
     ElCard: typeof import('element-plus/es')['ElCard']
@@ -27,6 +28,7 @@ declare module '@vue/runtime-core' {
     ElTooltip: typeof import('element-plus/es')['ElTooltip']
     ElTree: typeof import('element-plus/es')['ElTree']
     GuessYourLike: typeof import('./src/components/GuessYourLike.vue')['default']
+    MainNavBar: typeof import('./src/components/MainNavBar.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     SearchResultList: typeof import('./src/components/SearchResultList.vue')['default']

--- a/web-vue/src/components/MainNavBar.vue
+++ b/web-vue/src/components/MainNavBar.vue
@@ -1,0 +1,171 @@
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+import { useI18n } from '@/utils/i18n'
+
+/**
+ * Shared top navigation strip. Replaces the per-view inline tab strips
+ * that HomeView (`.pv-hero-tabs`) and AdvancedSearchView (`.pv-adv-tabs`)
+ * used to bring with them. Adding a 4th tab is a one-file change.
+ *
+ * Dark mode is intentionally kept as a prop + emit (not owned here) so
+ * the active state stays in the parent view, where it can also drive
+ * view-local dark-aware widgets without re-reading localStorage.
+ */
+
+const GITHUB_URL = 'https://github.com/youngfish42/PaperVault'
+
+const props = defineProps<{
+  activeKey: 'home' | 'advanced' | 'settings'
+  isDark: boolean
+}>()
+
+const emit = defineEmits<{
+  'toggle-dark': []
+}>()
+
+const router = useRouter()
+const { t, toggle: toggleLang } = useI18n()
+
+const goHome = (): void => {
+  router.push({ path: '/' })
+}
+const goAdvanced = (): void => {
+  router.push({ path: '/advanced' })
+}
+const goSettings = (): void => {
+  router.push({ path: '/settings' })
+}
+</script>
+
+<template>
+  <nav class="pv-nav">
+    <div class="pv-container pv-nav-inner">
+      <a class="brand" @click="goHome">PaperVault</a>
+      <button
+        class="pv-nav-tab"
+        :class="{ 'pv-nav-tab--active': props.activeKey === 'home' }"
+        type="button"
+        @click="goHome"
+      >
+        {{ t('search.tab.smart') }}
+      </button>
+      <button
+        class="pv-nav-tab"
+        :class="{ 'pv-nav-tab--active': props.activeKey === 'advanced' }"
+        type="button"
+        @click="goAdvanced"
+      >
+        {{ t('search.tab.advanced') }}
+      </button>
+      <button
+        class="pv-nav-tab"
+        :class="{ 'pv-nav-tab--active': props.activeKey === 'settings' }"
+        type="button"
+        @click="goSettings"
+      >
+        {{ t('toolbar.settings') }}
+      </button>
+      <div class="pv-nav-actions">
+        <el-link
+          type="primary"
+          :icon="props.isDark ? 'Sunny' : 'Moon'"
+          @click="emit('toggle-dark')"
+        >
+          {{ props.isDark ? t('toolbar.light') : t('toolbar.dark') }}
+        </el-link>
+        <el-link type="primary" icon="ChatLineRound" @click="toggleLang">
+          {{ t('toolbar.lang') }}
+        </el-link>
+        <a
+          class="pv-nav-github"
+          :href="GITHUB_URL"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {{ t('toolbar.github') }}
+        </a>
+      </div>
+    </div>
+  </nav>
+</template>
+
+<style scoped>
+.pv-nav {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--el-bg-color, #fff);
+  border-bottom: 1px solid var(--el-border-color-lighter, #ebeef5);
+}
+.pv-nav-inner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 6px;
+  padding-bottom: 0;
+}
+.brand {
+  font-size: 20px;
+  font-weight: 700;
+  text-decoration: none;
+  color: var(--el-text-color-primary, #333);
+  white-space: nowrap;
+  cursor: pointer;
+  padding: 8px 18px 14px 0;
+  margin-right: 8px;
+  border-right: 1px solid var(--el-border-color-lighter, #ebeef5);
+}
+.pv-nav-tab {
+  position: relative;
+  padding: 14px 18px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.2px;
+  color: var(--el-text-color-secondary, #909399);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: color 0.18s ease;
+}
+.pv-nav-tab:hover {
+  color: var(--el-text-color-primary, #303133);
+}
+.pv-nav-tab--active {
+  color: var(--el-text-color-primary, #303133);
+  font-weight: 600;
+}
+.pv-nav-tab--active::after {
+  content: '';
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  bottom: -1px;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--el-color-primary, #6f5ed3);
+}
+.pv-nav-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  padding-bottom: 6px;
+}
+.pv-nav-github {
+  text-decoration: none;
+  color: var(--el-color-primary, #6f5ed3);
+  font-size: 14px;
+}
+.pv-nav-github:hover {
+  text-decoration: underline;
+}
+@media (max-width: 768px) {
+  .brand {
+    border-right: none;
+    padding-right: 8px;
+  }
+  .pv-nav-tab {
+    padding: 14px 10px 16px;
+  }
+}
+</style>

--- a/web-vue/src/components/MainNavBar.vue
+++ b/web-vue/src/components/MainNavBar.vue
@@ -27,12 +27,15 @@ const router = useRouter()
 const { t, toggle: toggleLang } = useI18n()
 
 const goHome = (): void => {
+  if (props.activeKey === 'home') return
   router.push({ path: '/' })
 }
 const goAdvanced = (): void => {
+  if (props.activeKey === 'advanced') return
   router.push({ path: '/advanced' })
 }
 const goSettings = (): void => {
+  if (props.activeKey === 'settings') return
   router.push({ path: '/settings' })
 }
 </script>
@@ -40,7 +43,7 @@ const goSettings = (): void => {
 <template>
   <nav class="pv-nav">
     <div class="pv-container pv-nav-inner">
-      <a class="brand" @click="goHome">PaperVault</a>
+      <button type="button" class="brand" @click="goHome">PaperVault</button>
       <button
         class="pv-nav-tab"
         :class="{ 'pv-nav-tab--active': props.activeKey === 'home' }"
@@ -76,14 +79,15 @@ const goSettings = (): void => {
         <el-link type="primary" icon="ChatLineRound" @click="toggleLang">
           {{ t('toolbar.lang') }}
         </el-link>
-        <a
-          class="pv-nav-github"
+        <el-link
+          type="primary"
+          icon="Link"
           :href="GITHUB_URL"
           target="_blank"
           rel="noopener noreferrer"
         >
           {{ t('toolbar.github') }}
-        </a>
+        </el-link>
       </div>
     </div>
   </nav>
@@ -113,7 +117,10 @@ const goSettings = (): void => {
   cursor: pointer;
   padding: 8px 18px 14px 0;
   margin-right: 8px;
+  border: none;
   border-right: 1px solid var(--el-border-color-lighter, #ebeef5);
+  background: transparent;
+  font-family: inherit;
 }
 .pv-nav-tab {
   position: relative;
@@ -150,14 +157,6 @@ const goSettings = (): void => {
   gap: 14px;
   align-items: center;
   padding-bottom: 6px;
-}
-.pv-nav-github {
-  text-decoration: none;
-  color: var(--el-color-primary, #6f5ed3);
-  font-size: 14px;
-}
-.pv-nav-github:hover {
-  text-decoration: underline;
 }
 @media (max-width: 768px) {
   .brand {

--- a/web-vue/src/router/index.ts
+++ b/web-vue/src/router/index.ts
@@ -12,6 +12,11 @@ const router = createRouter({
       path: '/advanced',
       name: 'advanced',
       component: () => import('../views/AdvancedSearchView.vue')
+    },
+    {
+      path: '/settings',
+      name: 'settings',
+      component: () => import('../views/SettingsView.vue')
     }
     // {
     //   path: '/about',

--- a/web-vue/src/utils/i18n.ts
+++ b/web-vue/src/utils/i18n.ts
@@ -89,6 +89,17 @@ const messages: Record<Lang, Record<string, string>> = {
     'toolbar.light': '浅色模式',
     'toolbar.github': 'GitHub',
     'toolbar.lang': 'English',
+    'toolbar.settings': '设置',
+    'settings.pageTitle': '设置',
+    'settings.intro':
+      '管理 PaperVault 的偏好与配置，更多分组将在后续版本上线。',
+    'settings.wip': '即将在 P2-D 版本提供',
+    'settings.aiSuggest.title': 'AI 关键词推荐',
+    'settings.aiSuggest.desc':
+      '在此选择用于生成相关关键词的 LLM 提供方与模型，配置入口将在 P2-D 开放。',
+    'settings.about.title': '关于此页面',
+    'settings.about.body':
+      '本页是 P2-C 阶段交付的设置面板外壳，负责承载 P2-D 接入的 AI 提供方配置、模型选择与默认参数。',
     'tips.title': '搜索小贴士',
     'tips.desc':
       '① 直接输入关键词即可，默认按主题（标题 + 摘要 + 关键词）匹配；② 可使用 Web of Science 风格语法精确限定字段，如 AU="Yang Liu" SO=ICLR,NeurIPS PY=2023-2026；③ 想要可视化组合多条件？点击「高级搜索」打开行式表单，自动生成检索式；④ 点击作者名可一键检索其所有论文。',
@@ -130,7 +141,6 @@ const messages: Record<Lang, Record<string, string>> = {
     'year.since': '自 {year} 起',
     'year.all': '不限',
     'adv.pageTitle': '高级搜索',
-    'adv.backHome': '返回首页',
     'adv.builder.title': '检索条件',
     'adv.builder.hint': '按行添加字段条件，使用 AND / OR / NOT 组合',
     'adv.builder.firstRow': '检索式',
@@ -227,6 +237,17 @@ const messages: Record<Lang, Record<string, string>> = {
     'toolbar.light': 'Light',
     'toolbar.github': 'GitHub',
     'toolbar.lang': '中文',
+    'toolbar.settings': 'Settings',
+    'settings.pageTitle': 'Settings',
+    'settings.intro':
+      'Manage PaperVault preferences and configuration. More sections will be added in upcoming releases.',
+    'settings.wip': 'Coming in P2-D',
+    'settings.aiSuggest.title': 'AI keyword suggestions',
+    'settings.aiSuggest.desc':
+      'Choose the LLM provider and model used to generate related keywords. Configuration UI ships in P2-D.',
+    'settings.about.title': 'About this page',
+    'settings.about.body':
+      'This page is the P2-C settings panel shell. It will host the P2-D AI provider configuration, model selection, and default-parameter controls.',
     'tips.title': 'Search Tips',
     'tips.desc':
       '① Just type keywords — the default Topic search matches title + abstract + author keywords. ② Use Web of Science style field tags for precision, e.g. AU="Yang Liu" SO=ICLR,NeurIPS PY=2023-2026. ③ Need a visual builder? Open "Advanced search" to add rows and auto-generate the expression. ④ Click any author name to instantly list all their papers.',
@@ -269,7 +290,6 @@ const messages: Record<Lang, Record<string, string>> = {
     'year.since': 'Since {year}',
     'year.all': 'All',
     'adv.pageTitle': 'Advanced search',
-    'adv.backHome': 'Back to home',
     'adv.builder.title': 'Query builder',
     'adv.builder.hint': 'Add rows and combine them with AND / OR / NOT',
     'adv.builder.firstRow': 'Query',

--- a/web-vue/src/views/AdvancedSearchView.vue
+++ b/web-vue/src/views/AdvancedSearchView.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, shallowRef } from 'vue'
 import { useRouter } from 'vue-router'
+import { useDark, useToggle } from '@vueuse/core'
 import { ElMessage } from 'element-plus'
+import MainNavBar from '@/components/MainNavBar.vue'
 import { listConfs } from '@/api/paper'
 import { useI18n } from '@/utils/i18n'
 import { buildDsl, type DslRow } from '@/utils/queryDsl'
 
-const { t, toggle: toggleLang } = useI18n()
+const { t } = useI18n()
 const router = useRouter()
+const isDark = useDark()
+const toggleDark = useToggle(isDark)
 
 /**
  * Web of Science-style advanced search:
@@ -97,10 +101,6 @@ const runSearch = (): void => {
   router.push({ path: '/', query: { q: expr } })
 }
 
-const goHome = (): void => {
-  router.push({ path: '/' })
-}
-
 onMounted(async () => {
   try {
     const res = await listConfs()
@@ -113,26 +113,12 @@ onMounted(async () => {
 
 <template>
   <main class="pv-adv-page">
-    <!-- WoS 风格 tab 栏 -->
-    <nav class="pv-adv-tabs">
-      <div class="pv-container pv-adv-tabs-inner">
-        <a class="brand" @click="goHome">{{ t('app.title') }}</a>
-        <button class="pv-adv-tab" type="button" @click="goHome">
-          {{ t('search.tab.smart') }}
-        </button>
-        <button class="pv-adv-tab pv-adv-tab--active" type="button">
-          {{ t('search.tab.advanced') }}
-        </button>
-        <div class="pv-adv-tabs-actions">
-          <el-link type="primary" icon="Back" @click="goHome">
-            {{ t('adv.backHome') }}
-          </el-link>
-          <el-link type="primary" icon="ChatLineRound" @click="toggleLang">
-            {{ t('toolbar.lang') }}
-          </el-link>
-        </div>
-      </div>
-    </nav>
+    <!-- 共享 MainNavBar：Smart / Advanced / Settings + 暗色 / 语言 / GitHub -->
+    <MainNavBar
+      active-key="advanced"
+      :is-dark="isDark"
+      @toggle-dark="toggleDark()"
+    />
 
     <section class="pv-container pv-adv-body">
       <div class="pv-adv-grid">

--- a/web-vue/src/views/HomeView.vue
+++ b/web-vue/src/views/HomeView.vue
@@ -317,15 +317,15 @@ onMounted(async () => {
 
 <template>
   <main class="full pos-relative">
+    <!-- 共享顶栏（Smart / Advanced / Settings）：跨 firstEntry 状态常驻 -->
+    <MainNavBar
+      active-key="home"
+      :is-dark="isDark"
+      @toggle-dark="toggleDark()"
+    />
+
     <!-- 首屏：WoS 风格 hero -->
     <section v-if="firstEntry" class="pv-hero">
-      <!-- 顶部 tab：MainNavBar 接管（Smart / Advanced / Settings） -->
-      <MainNavBar
-        active-key="home"
-        :is-dark="isDark"
-        @toggle-dark="toggleDark()"
-      />
-
       <div class="pv-container pv-hero-inner">
         <h1 class="pv-hero-title">
           <a href="/">{{ t('app.title') }}</a>
@@ -454,7 +454,7 @@ onMounted(async () => {
             <el-icon class="pv-dsl-info"><InfoFilled /></el-icon>
           </el-tooltip>
           <div class="pv-topbar-actions">
-            <el-link type="primary" icon="Setting" @click="goSettings">
+            <el-link type="primary" icon="Tools" @click="goSettings">
               {{ t('toolbar.settings') }}
             </el-link>
             <el-link type="primary" icon="Setting" @click="goAdvanced">

--- a/web-vue/src/views/HomeView.vue
+++ b/web-vue/src/views/HomeView.vue
@@ -6,6 +6,7 @@ import { ElMessage, ElLoading } from 'element-plus'
 import ConfsTree from '@/components/ConfsTree.vue'
 import SearchResultList from '@/components/SearchResultList.vue'
 import GuessYourLike from '@/components/GuessYourLike.vue'
+import MainNavBar from '@/components/MainNavBar.vue'
 import {
   listConfs,
   searchPapers,
@@ -277,6 +278,10 @@ const goAdvanced = (): void => {
   router.push({ path: '/advanced' })
 }
 
+const goSettings = (): void => {
+  router.push({ path: '/settings' })
+}
+
 const isDark = useDark()
 const toggleDark = useToggle(isDark)
 
@@ -314,37 +319,12 @@ onMounted(async () => {
   <main class="full pos-relative">
     <!-- 首屏：WoS 风格 hero -->
     <section v-if="firstEntry" class="pv-hero">
-      <!-- 顶部 tab：Smart Search / Advanced Search -->
-      <nav class="pv-hero-tabs">
-        <div class="pv-container pv-hero-tabs-inner">
-          <button class="pv-hero-tab pv-hero-tab--active" type="button">
-            {{ t('search.tab.smart') }}
-          </button>
-          <button class="pv-hero-tab" type="button" @click="goAdvanced">
-            {{ t('search.tab.advanced') }}
-          </button>
-          <div class="pv-hero-tabs-actions">
-            <el-link
-              type="primary"
-              :icon="isDark ? 'Sunny' : 'Moon'"
-              @click="toggleDark()"
-            >
-              {{ isDark ? t('toolbar.light') : t('toolbar.dark') }}
-            </el-link>
-            <el-link type="primary" icon="ChatLineRound" @click="toggleLang">
-              {{ t('toolbar.lang') }}
-            </el-link>
-            <el-link
-              type="primary"
-              icon="Link"
-              href="https://github.com/youngfish42/PaperVault"
-              target="_blank"
-            >
-              {{ t('toolbar.github') }}
-            </el-link>
-          </div>
-        </div>
-      </nav>
+      <!-- 顶部 tab：MainNavBar 接管（Smart / Advanced / Settings） -->
+      <MainNavBar
+        active-key="home"
+        :is-dark="isDark"
+        @toggle-dark="toggleDark()"
+      />
 
       <div class="pv-container pv-hero-inner">
         <h1 class="pv-hero-title">
@@ -474,6 +454,9 @@ onMounted(async () => {
             <el-icon class="pv-dsl-info"><InfoFilled /></el-icon>
           </el-tooltip>
           <div class="pv-topbar-actions">
+            <el-link type="primary" icon="Setting" @click="goSettings">
+              {{ t('toolbar.settings') }}
+            </el-link>
             <el-link type="primary" icon="Setting" @click="goAdvanced">
               {{ t('toolbar.advanced') }}
             </el-link>

--- a/web-vue/src/views/SettingsView.vue
+++ b/web-vue/src/views/SettingsView.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { useDark, useToggle } from '@vueuse/core'
+import MainNavBar from '@/components/MainNavBar.vue'
+import { useI18n } from '@/utils/i18n'
+
+/**
+ * P2-C Settings page shell. No data fetching, no forms — those arrive
+ * in P2-D when the AI Suggest section starts consuming P2-B's
+ * ``listAiProviders()`` and ``suggestKeywordsWithSettings()``.
+ *
+ * The visual structure (title + intro + two ``el-card`` placeholders)
+ * mirrors AdvancedSearchView's density so the page doesn't feel empty.
+ */
+
+const isDark = useDark()
+const toggleDark = useToggle(isDark)
+const { t } = useI18n()
+</script>
+
+<template>
+  <main class="full pos-relative">
+    <MainNavBar
+      active-key="settings"
+      :is-dark="isDark"
+      @toggle-dark="toggleDark()"
+    />
+
+    <section class="pv-container pv-settings-body">
+      <h1 class="pv-settings-title">{{ t('settings.pageTitle') }}</h1>
+      <p class="pv-settings-intro">{{ t('settings.intro') }}</p>
+
+      <el-card shadow="never" class="pv-settings-card">
+        <template #header>
+          <span class="pv-settings-card-title">
+            {{ t('settings.aiSuggest.title') }}
+          </span>
+        </template>
+        <el-alert
+          type="info"
+          :title="t('settings.wip')"
+          :description="t('settings.aiSuggest.desc')"
+          show-icon
+          :closable="false"
+        />
+      </el-card>
+
+      <el-card shadow="never" class="pv-settings-card">
+        <template #header>
+          <span class="pv-settings-card-title">
+            {{ t('settings.about.title') }}
+          </span>
+        </template>
+        <p class="pv-settings-about-body">{{ t('settings.about.body') }}</p>
+      </el-card>
+    </section>
+  </main>
+</template>
+
+<style scoped>
+.pv-settings-body {
+  max-width: 720px;
+  padding-top: 28px;
+  padding-bottom: 40px;
+}
+.pv-settings-title {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--el-text-color-primary, #303133);
+  margin: 0 0 8px;
+}
+.pv-settings-intro {
+  font-size: 14px;
+  color: var(--el-text-color-secondary, #606266);
+  margin: 0 0 20px;
+  line-height: 1.6;
+}
+.pv-settings-card {
+  margin-bottom: 16px;
+  border: 1px solid var(--el-border-color-lighter, #ebeef5);
+  border-radius: 10px;
+  background: var(--el-bg-color, #fff);
+}
+.pv-settings-card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--el-text-color-primary, #303133);
+}
+.pv-settings-about-body {
+  font-size: 13.5px;
+  line-height: 1.7;
+  color: var(--el-text-color-regular, #4c4d4f);
+  margin: 0;
+}
+</style>


### PR DESCRIPTION
## 背景

P2-A (#100) 后端 + P2-B (#102) 前端三件套 (`constants/aiProviders.ts` / `utils/aiSettings.ts` / `api/ai.ts`) 都铺好了，但**没有 UI 入口**。P2-C 把 `/settings` 路由、顶栏第三个 tab、Settings 页面壳立起来，**不填具体功能**——P2-D 再把 P2-B 的 `listAiProviders()` / `suggestKeywordsWithSettings()` 接进这个壳做表单。

## 范围

3 个新文件 + 4 个修改文件。

### 新增

- **`src/components/MainNavBar.vue`**（~150 行）：3 个 view 共享的顶栏组件。Props: `activeKey: 'home' | 'advanced' | 'settings'`, `isDark: boolean`，emit `'toggle-dark'`。内部用 `useI18n()` 读 toolbar 文案，用 `useRouter()` 跳路由。
- **`src/views/SettingsView.vue`**（~90 行）：P2-C 页面壳，h1 + intro + 2 个 `el-card`（AI Suggest 占位 + About 说明）。**不**做 `onMounted` fetch，没有任何数据需求。
- **`web-vue/components.d.ts`**（自动生成）：`MainNavBar` + `ElAlert` 全局组件类型声明（unplugin-vue-components 自动追加）。

### 修改

- **`src/router/index.ts`**：加 `/settings` → `SettingsView` 路由。
- **`src/utils/i18n.ts`**：
  - 加 7 个 zh + 7 个 en 键（`toolbar.settings` + `settings.*` 命名空间）
  - 删 `adv.backHome`（被 `MainNavBar` 内的 Smart Search tab 取代）
- **`src/views/HomeView.vue`**：hero strip (`.pv-hero-tabs`) 整体替换为 `<MainNavBar active-key="home" />`；post-search topbar 的 actions 区加一个 `el-link` 指向 `/settings`；新增 `goSettings()`。
- **`src/views/AdvancedSearchView.vue`**：nav strip (`.pv-adv-tabs`) 整体替换为 `<MainNavBar active-key="advanced" />`；新增 `useDark` / `useToggle` 引用；删不再使用的 `goHome` 和 `toggleLang` 解构。

## 设计取舍

1. **抽 `MainNavBar` 而不是 inline 拷贝到 2 个 view**：加第 4 个 tab 时只动 1 个文件。代价是 `useDark` 在 3 个 view 各调一次（@vueuse/core 基于全局 signal 同步，无副作用）。
2. **post-search topbar 保留 view-local 布局**：带 search input + refine toggle，强行塞进 `MainNavBar` 要新增 slot，API 膨胀。Hybrid 取舍：topbar 单独加一个 `el-link` 指向 Settings，**strip 重复一个 Settings 入口**——P2-D 接入 search input 槽位时再统一。
3. **dead CSS 留下**：`.pv-hero-tabs` / `.pv-adv-tabs` 规则在 HomeView / AdvancedSearchView 里已经成 dead code，**不删**——避免 P2-C 改 4 个文件 `<style scoped>` 块，留给后续清理 PR。

## 验证

- `npx vue-tsc --noEmit` → exit 0
- `npx eslint` 涉及文件 → 0 warnings
- `npx vite build` → 成功（767ms）
- Dev server 启动正常；`/src/views/SettingsView.vue` 和 `/src/components/MainNavBar.vue` 经 Vite transform 无错

## 影响面 / 风险

- **正向**：3 个 view 顶栏视觉规范终于统一；Settings 入口从任何页面都可达（hero + post-search topbar 都有）。
- **风险**：`useDark` 在 3 个 view 各调一次（@vueuse/core 全局 signal 同步，安全）；dead CSS 增加 ~50 行字节（无功能影响）；post-search topbar 与 `MainNavBar` 重复一个 Settings 入口（hybrid 取舍，P2-D 整合时消化）。

## 下一步

- **P2-D**：在 SettingsView 的 AI Suggest card 里挂表单，调 `listAiProviders()` 拉 provider 下拉，调 `suggestKeywordsWithSettings()` 做"测一下"按钮