### PR TITLE
fix(web): ConfsTree 高度自适应视口，内部可滚动

### DIFF
--- a/web-vue/src/assets/main.css
+++ b/web-vue/src/assets/main.css
@@ -3,6 +3,8 @@
 :root {
   --pv-max-width: 1600px;
   --pv-gutter: 16px;
+  --pv-topbar-h: 70px;
+  --pv-side-gap: 20px;
 }
 
 #app {

--- a/web-vue/src/assets/main.css
+++ b/web-vue/src/assets/main.css
@@ -3,8 +3,13 @@
 :root {
   --pv-max-width: 1600px;
   --pv-gutter: 16px;
-  --pv-topbar-h: 70px;
-  --pv-side-gap: 20px;
+  /* Vertical offset applied to sticky elements that must sit below the
+     topbar (e.g. .pv-side, .pv-adv-cheatsheet). Includes the topbar's own
+     rendered height plus a small breathing gap. */
+  --pv-sticky-top: 70px;
+  /* Bottom breathing room reserved under a sticky sidebar so long content
+     (e.g. ConfsTree) does not butt up against the viewport bottom. */
+  --pv-side-bottom-gap: 20px;
 }
 
 #app {

--- a/web-vue/src/components/ConfsTree.vue
+++ b/web-vue/src/components/ConfsTree.vue
@@ -135,11 +135,11 @@ watch(lang, () => rebuild(props.data))
      dragging the page or hunting for a tiny custom-scrollbar. */
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - var(--pv-topbar-h) - var(--pv-side-gap));
-  max-height: calc(100dvh - var(--pv-topbar-h) - var(--pv-side-gap));
+  max-height: calc(100vh - var(--pv-sticky-top) - var(--pv-side-bottom-gap));
+  max-height: calc(100dvh - var(--pv-sticky-top) - var(--pv-side-bottom-gap));
   overflow: hidden;
 }
-.tree-card :deep(.el-card__body) {
+.tree-card > :deep(.el-card__body) {
   /* Element Plus wraps default-slot content in .el-card__body (a plain
      block by default). We need it to become a bounded flex column so the
      inner .tree-card-scroll actually receives a height and its

--- a/web-vue/src/components/ConfsTree.vue
+++ b/web-vue/src/components/ConfsTree.vue
@@ -112,7 +112,7 @@ watch(lang, () => rebuild(props.data))
 </script>
 <template>
   <el-card class="tree-card pv-compact-card" shadow="never">
-    <el-scrollbar height="320px">
+    <div class="tree-card-scroll">
       <el-tree
         :data="tree"
         :props="defaultProps"
@@ -121,7 +121,7 @@ watch(lang, () => rebuild(props.data))
         :default-expand-all="true"
         @node-click="treeNodeClick"
       />
-    </el-scrollbar>
+    </div>
     <div v-if="props.meta?.truncated" class="tree-truncated-hint">
       {{ t('tree.truncatedHint').replace('{n}', String(fetchedCount)) }}
     </div>
@@ -131,11 +131,32 @@ watch(lang, () => rebuild(props.data))
 <style scoped>
 .tree-card {
   user-select: none;
+  /* The card lives in a sticky .pv-side that sits under the 70px topbar,
+     so cap it to the rest of the viewport. The body becomes the scroll
+     container below, so the user can browse a 200-venue list without
+     dragging the page or hunting for a tiny custom-scrollbar. */
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 90px);
+  overflow: hidden;
+}
+.tree-card-scroll {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  /* Slim native scrollbar on desktop; falls back to overlay on touch. */
+  scrollbar-width: thin;
+}
+.tree-card-scroll :deep(.el-tree) {
+  /* el-tree renders an inline-block wrapper that constrains to its
+     children's width; let it stretch so empty horizontal space doesn't
+     look like a layout bug once we have a vertical scrollbar. */
+  min-width: 100%;
 }
 .tree-card :deep(.el-tree-node__label) {
   font-size: 13px;
 }
 .tree-truncated-hint {
+  flex: 0 0 auto;
   margin-top: 8px;
   padding: 6px 8px;
   font-size: 12px;

--- a/web-vue/src/components/ConfsTree.vue
+++ b/web-vue/src/components/ConfsTree.vue
@@ -1,10 +1,6 @@
 <!--
- * @Author: 0x3E5
- * @Date: 2023-02-12 17:29:45
- * @LastEditTime: 2023-03-06 10:34:09
- * @LastEditors: 0x3E5
- * @Description: 
- * @FilePath: \web-vue\src\components\ConfsTree.vue
+ * @Description: Conference / year filter tree rendered in the sticky sidebar.
+ * @FilePath: web-vue/src/components/ConfsTree.vue
 -->
 <script setup lang="ts">
 import { computed, ref, shallowRef, watch } from 'vue'
@@ -131,17 +127,32 @@ watch(lang, () => rebuild(props.data))
 <style scoped>
 .tree-card {
   user-select: none;
-  /* The card lives in a sticky .pv-side that sits under the 70px topbar,
-     so cap it to the rest of the viewport. The body becomes the scroll
+  /* The card lives in a sticky .pv-side that sits under the topbar, so cap
+     it to the rest of the viewport. Use 100dvh so the dynamic mobile URL bar
+     does not push the scroll region past the visible area; fall back to
+     100vh on browsers without dvh support. The body becomes the scroll
      container below, so the user can browse a 200-venue list without
      dragging the page or hunting for a tiny custom-scrollbar. */
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - 90px);
+  max-height: calc(100vh - var(--pv-topbar-h) - var(--pv-side-gap));
+  max-height: calc(100dvh - var(--pv-topbar-h) - var(--pv-side-gap));
+  overflow: hidden;
+}
+.tree-card :deep(.el-card__body) {
+  /* Element Plus wraps default-slot content in .el-card__body (a plain
+     block by default). We need it to become a bounded flex column so the
+     inner .tree-card-scroll actually receives a height and its
+     overflow-y:auto produces a scrollbar instead of being clipped. */
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: hidden;
 }
 .tree-card-scroll {
   flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
   /* Slim native scrollbar on desktop; falls back to overlay on touch. */
   scrollbar-width: thin;

--- a/web-vue/src/views/AdvancedSearchView.vue
+++ b/web-vue/src/views/AdvancedSearchView.vue
@@ -459,7 +459,7 @@ onMounted(async () => {
 /* ---------- 右侧 cheatsheet ---------- */
 .pv-adv-cheatsheet {
   position: sticky;
-  top: var(--pv-topbar-h);
+  top: var(--pv-sticky-top);
 }
 .pv-adv-cheatsheet-title {
   font-size: 15px;

--- a/web-vue/src/views/AdvancedSearchView.vue
+++ b/web-vue/src/views/AdvancedSearchView.vue
@@ -459,7 +459,7 @@ onMounted(async () => {
 /* ---------- 右侧 cheatsheet ---------- */
 .pv-adv-cheatsheet {
   position: sticky;
-  top: 70px;
+  top: var(--pv-topbar-h);
 }
 .pv-adv-cheatsheet-title {
   font-size: 15px;

--- a/web-vue/src/views/HomeView.vue
+++ b/web-vue/src/views/HomeView.vue
@@ -810,7 +810,7 @@ onMounted(async () => {
 }
 .pv-side {
   position: sticky;
-  top: 70px;
+  top: var(--pv-topbar-h);
 }
 @media (max-width: 1200px) {
   .pv-main {

--- a/web-vue/src/views/HomeView.vue
+++ b/web-vue/src/views/HomeView.vue
@@ -810,7 +810,7 @@ onMounted(async () => {
 }
 .pv-side {
   position: sticky;
-  top: var(--pv-topbar-h);
+  top: var(--pv-sticky-top);
 }
 @media (max-width: 1200px) {
   .pv-main {


### PR DESCRIPTION
## 背景

旧实现 `<el-scrollbar height=\"320px\">` 把左侧会议树的滚动区写死成 320px。对一个 200+ 会议库来说根本装不下——`default-expand-all=true` 一开就溢出了，用户展开 NeurIPS (33) 时年份子节点被裁在底部栏外，只能整页拖才能看见。

## 改动

`web-vue/src/components/ConfsTree.vue`：

- 去掉 `<el-scrollbar height=\"320px\">` 包装
- `.tree-card` 改成 flex column，`max-height: calc(100vh - 90px)`（90 = sticky 顶栏 70px + 上下 padding）
- `.tree-card-scroll` 子 div 改成 `flex: 1 1 auto; overflow-y: auto; scrollbar-width: thin`——自身做滚动容器，原生 scrollbar 比 el-scrollbar 的小细条好抓
- `truncated-hint` 改成 `flex: 0 0 auto` 保留在卡片底部，不被滚动带走

## 验证

- `vue-tsc --noEmit` 通过
- `npm run build` 成功
- 硬刷浏览器后，ConfsTree 跟视口同步，72+ conf / 年份子节点在栏内可直接滚动

## 风险

零行为变更——`formatData` / `treeNodeClick` / watch 全部不动，只改 CSS layout。