### PR TITLE
Adjust/backfill daily and force

### DIFF
--- a/.github/workflows/backfill_abstracts.yml
+++ b/.github/workflows/backfill_abstracts.yml
@@ -10,14 +10,19 @@ env:
 
 on:
   schedule:
-    # 每 6 小时运行一次 (UTC 00:00 / 06:00 / 12:00 / 18:00)，运行时长由 --soft-timeout 控制（约5小时后自动保存进度退出）
-    - cron: "0 */6 * * *"
+    # 每天运行一次 (UTC 00:00)，运行时长由 --soft-timeout 控制（约5小时后自动保存进度退出）
+    - cron: "0 0 * * *"
   workflow_dispatch:
     inputs:
       target_conf:
         description: "手动指定 conf（如 AAAI2020），留空则自动处理最高优先级论文，直到时间耗尽"
         required: false
         default: ""
+      force:
+        description: "强制获取摘要：即使论文之前获取摘要失败也继续尝试（默认关闭；不会覆盖已有摘要）"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   # Shared with collect_papers / update_readme to serialise every workflow
@@ -141,10 +146,14 @@ jobs:
 
       - name: Run abstract backfill
         run: |
+          force_flag=""
+          if [ "${{ github.event.inputs.force }}" = "true" ]; then
+            force_flag="--force"
+          fi
           if [ -n "${{ github.event.inputs.target_conf }}" ]; then
-            python scripts/fetch_abstracts.py --conf "${{ github.event.inputs.target_conf }}" --chunk-size 500 --soft-timeout 14400 --max-failed-attempts 3
+            python scripts/fetch_abstracts.py --conf "${{ github.event.inputs.target_conf }}" --chunk-size 500 --soft-timeout 14400 --max-failed-attempts 3 $force_flag
           else
-            python scripts/fetch_abstracts.py --batch --chunk-size 500 --soft-timeout 14400 --max-failed-attempts 3
+            python scripts/fetch_abstracts.py --batch --chunk-size 500 --soft-timeout 14400 --max-failed-attempts 3 $force_flag
           fi
 
       - name: Retry recoverable failures (--reason-in whitelist)
@@ -173,10 +182,14 @@ jobs:
         if: success() || failure()
         timeout-minutes: 70
         run: |
+          force_flag=""
+          if [ "${{ github.event.inputs.force }}" = "true" ]; then
+            force_flag="--force"
+          fi
           if [ -n "${{ github.event.inputs.target_conf }}" ]; then
-            python scripts/fetch_abstracts.py --conf "${{ github.event.inputs.target_conf }}" --chunk-size 500 --soft-timeout 3600 --max-failed-attempts 3 --retry-failed --reason-in "rate_limited,timeout,network,empty_abstract" --no-include-legacy
+            python scripts/fetch_abstracts.py --conf "${{ github.event.inputs.target_conf }}" --chunk-size 500 --soft-timeout 3600 --max-failed-attempts 3 --retry-failed --reason-in "rate_limited,timeout,network,empty_abstract" --no-include-legacy $force_flag
           else
-            python scripts/fetch_abstracts.py --batch --chunk-size 500 --soft-timeout 3600 --max-failed-attempts 3 --retry-failed --reason-in "rate_limited,timeout,network,empty_abstract" --no-include-legacy
+            python scripts/fetch_abstracts.py --batch --chunk-size 500 --soft-timeout 3600 --max-failed-attempts 3 --retry-failed --reason-in "rate_limited,timeout,network,empty_abstract" --no-include-legacy $force_flag
           fi
 
       - name: Backfill CVF Open Access abstracts
@@ -188,11 +201,15 @@ jobs:
         # within the same job. `--soft-timeout 2400` (40 min) keeps the total
         # workflow well under the 330 min hard cap.
         run: |
+          force_flag=""
+          if [ "${{ github.event.inputs.force }}" = "true" ]; then
+            force_flag="--force"
+          fi
           if [ -n "${{ github.event.inputs.target_conf }}" ]; then
             read -r -a confs <<< "${{ github.event.inputs.target_conf }}"
-            python scripts/fetch_cvf_abstracts.py --conf "${confs[@]}" --soft-timeout 2400
+            python scripts/fetch_cvf_abstracts.py --conf "${confs[@]}" --soft-timeout 2400 $force_flag
           else
-            python scripts/fetch_cvf_abstracts.py --soft-timeout 2400
+            python scripts/fetch_cvf_abstracts.py --soft-timeout 2400 $force_flag
           fi
 
       - name: Scan GitHub code links from newly backfilled abstracts

--- a/scripts/fetch_abstracts.py
+++ b/scripts/fetch_abstracts.py
@@ -1203,6 +1203,7 @@ def _process_targets(
     progress: Dict[str, dict] = None,
     reason_in: Optional[Set[str]] = None,
     include_legacy: bool = True,
+    force: bool = False,
 ) -> Tuple[int, int, bool]:
     """处理一组目标论文，返回 (success_count, failed_count, timed_out)。
 
@@ -1217,11 +1218,24 @@ def _process_targets(
     workflows that must strictly honour the reason whitelist — e.g. the
     Actions retry step which is intentionally scoped to recoverable
     failures only.
+
+    ``force`` — when ``True``, retry papers that previously failed to fetch
+    an abstract, including those whose ``attempts`` have reached
+    ``max_failed_attempts``. Papers already marked as successful are still
+    skipped.
     """
     if progress is None:
         progress = load_progress()
     if not retry_failed and not retry_partial:
-        targets = [p for p in targets if p.get("paper_url") not in progress]
+        if force:
+            # 强制模式：只跳过已成功论文，失败论文继续尝试
+            targets = [
+                p for p in targets
+                if p.get("paper_url") not in progress
+                or progress[p.get("paper_url")].get("status") != "success"
+            ]
+        else:
+            targets = [p for p in targets if p.get("paper_url") not in progress]
     elif retry_partial:
         cache_has_abs = {p.get("paper_url", ""): (p.get("paper_abstract") or "").strip() for p in all_papers}
         partial_urls = {
@@ -1233,7 +1247,7 @@ def _process_targets(
     else:
         failed_urls = {
             url for url, meta in progress.items()
-            if meta.get("status") == "failed" and meta.get("attempts", 0) < max_failed_attempts
+            if meta.get("status") == "failed" and (force or meta.get("attempts", 0) < max_failed_attempts)
         }
         if reason_in is not None:
             # ``normalize_reason`` guarantees an in-vocab value; records
@@ -1363,6 +1377,7 @@ def run(
     include_legacy: bool = True,
     no_sync: bool = False,
     offline: bool = False,
+    force: bool = False,
 ) -> None:
     global_start = time.time()
     # Pull the latest cache from Hugging Face before reading/writing anything.
@@ -1381,6 +1396,8 @@ def run(
     if soft_timeout:
         print(f"[*] Soft timeout: {soft_timeout}s ({soft_timeout/3600:.1f}h)")
     print(f"[*] Max failed attempts before permanently skipping: {max_failed_attempts}")
+    if force:
+        print("[*] Force mode: ENABLED — will retry papers that previously failed to fetch an abstract")
 
     # 1. 读取所有论文
     all_papers = []
@@ -1411,6 +1428,7 @@ def run(
                 skip_urls.add(url)
             elif (
                 not retry_partial
+                and not force
                 and meta.get("status") == "failed"
                 and meta.get("attempts", 0) >= max_failed_attempts
             ):
@@ -1453,7 +1471,7 @@ def run(
         if top_n:
             target_confs = target_confs[:top_n]
         # 预过滤：提前剔除所有论文都已在 progress 中的会议，避免空转
-        if not retry_failed and not retry_partial:
+        if not retry_failed and not retry_partial and not force:
             progress = load_progress()
             target_confs = [
                 conf for conf in target_confs
@@ -1490,6 +1508,7 @@ def run(
             progress=progress,
             reason_in=reason_in,
             include_legacy=include_legacy,
+            force=force,
         )
         if success > 0:
             if no_sync or offline:
@@ -1535,6 +1554,7 @@ def run(
             conf_papers, all_papers, chunk_size, retry_failed, retry_partial, query_doi_by_title,
             start_time=global_start, soft_timeout=soft_timeout, max_failed_attempts=max_failed_attempts,
             progress=progress, reason_in=reason_in, include_legacy=include_legacy,
+            force=force,
         )
         attempted = success + failed
         processed_total += attempted
@@ -1631,6 +1651,16 @@ if __name__ == "__main__":
             "refreshed the local copy in the same shell)."
         ),
     )
+    parser.add_argument(
+        "--force",
+        dest="force",
+        action="store_true",
+        help=(
+            "Force retry: also attempt papers whose abstract fetch previously "
+            "failed, including those that have reached --max-failed-attempts. "
+            "Does NOT re-fetch papers that already have a non-empty abstract."
+        ),
+    )
     args = parser.parse_args()
     reason_in_set: Optional[Set[str]] = None
     if args.reason_in:
@@ -1652,4 +1682,5 @@ if __name__ == "__main__":
         include_legacy=args.include_legacy,
         no_sync=args.no_sync,
         offline=args.offline,
+        force=args.force,
     )

--- a/scripts/fetch_cvf_abstracts.py
+++ b/scripts/fetch_cvf_abstracts.py
@@ -188,6 +188,7 @@ def build_task(
     year_filter: Optional[Set[int]],
     retry_failed: bool,
     progress: dict,
+    force: bool = False,
 ) -> List[Tuple[int, str]]:
     filled_set = set(progress.get("filled", []))
     tried_set = set(progress.get("tried", []))
@@ -204,9 +205,9 @@ def build_task(
             continue
         if year_filter and conf_year(conf_name) not in year_filter:
             continue
-        if url in filled_set:
+        if not force and url in filled_set:
             continue
-        if not retry_failed and url in tried_set:
+        if not retry_failed and not force and url in tried_set:
             continue
         tasks.append((idx, url))
     return tasks
@@ -230,6 +231,8 @@ def run(args) -> int:
     print(f"[*] Loading cache: {CACHE_FILE}")
     records = load_cache(CACHE_FILE)
     print(f"    Loaded {len(records)} records")
+    if args.force:
+        print("[*] Force mode: ENABLED — will retry CVF papers that previously failed to fetch an abstract")
 
     progress = load_progress()
     conf_filter = set(args.conf) if args.conf else None
@@ -241,6 +244,7 @@ def run(args) -> int:
         year_filter=year_filter,
         retry_failed=args.retry_failed,
         progress=progress,
+        force=args.force,
     )
 
     per_conf: Dict[str, int] = {}
@@ -462,6 +466,8 @@ def parse_args(argv=None) -> argparse.Namespace:
                    help="只打印任务集，不发起请求、不写文件")
     p.add_argument("--retry-failed", action="store_true",
                    help="重试之前 tried 但未拿到 abstract 的 URL")
+    p.add_argument("--force", action="store_true",
+                   help="强制重试：即使 URL 之前 tried 过也再次尝试获取 abstract（不覆盖已有摘要）")
     p.add_argument("--always-flush", action="store_true",
                    help="即使本轮无新增，也写一次 cache（默认仅在有新增时写）")
     p.add_argument("--no-sync", action="store_true",

--- a/scripts/fetch_cvf_abstracts.py
+++ b/scripts/fetch_cvf_abstracts.py
@@ -188,6 +188,7 @@ def build_task(
     year_filter: Optional[Set[int]],
     retry_failed: bool,
     progress: dict,
+    force: bool = False,
 ) -> List[Tuple[int, str]]:
     filled_set = set(progress.get("filled", []))
     tried_set = set(progress.get("tried", []))
@@ -206,7 +207,7 @@ def build_task(
             continue
         if url in filled_set:
             continue
-        if not retry_failed and url in tried_set:
+        if not retry_failed and not force and url in tried_set:
             continue
         tasks.append((idx, url))
     return tasks
@@ -230,6 +231,8 @@ def run(args) -> int:
     print(f"[*] Loading cache: {CACHE_FILE}")
     records = load_cache(CACHE_FILE)
     print(f"    Loaded {len(records)} records")
+    if args.force:
+        print("[*] Force mode: ENABLED — will retry CVF papers that previously failed to fetch an abstract")
 
     progress = load_progress()
     conf_filter = set(args.conf) if args.conf else None
@@ -241,6 +244,7 @@ def run(args) -> int:
         year_filter=year_filter,
         retry_failed=args.retry_failed,
         progress=progress,
+        force=args.force,
     )
 
     per_conf: Dict[str, int] = {}
@@ -462,6 +466,8 @@ def parse_args(argv=None) -> argparse.Namespace:
                    help="只打印任务集，不发起请求、不写文件")
     p.add_argument("--retry-failed", action="store_true",
                    help="重试之前 tried 但未拿到 abstract 的 URL")
+    p.add_argument("--force", action="store_true",
+                   help="强制重试：即使 URL 之前 tried 过也再次尝试获取 abstract（不覆盖已有摘要）")
     p.add_argument("--always-flush", action="store_true",
                    help="即使本轮无新增，也写一次 cache（默认仅在有新增时写）")
     p.add_argument("--no-sync", action="store_true",


### PR DESCRIPTION
## 摘要

将摘要回填工作流调整为每天运行一次，并在手动触发时增加"强制重试"选项。

## 改动

### `.github/workflows/backfill_abstracts.yml`
- 定时触发从每 6 小时一次（`0 */6 * * *`）改为每天一次（`0 0 * * *`）。
- 新增 `workflow_dispatch` 布尔输入 `force`（默认关闭）。
- 勾选 `force` 后，三个回填步骤都会传递 `--force`：
  - 主摘要回填
  - 可恢复失败重试
  - CVF Open Access 回填

### `scripts/fetch_abstracts.py`
- 新增 `--force` 参数。
- 强制模式下会重试之前获取摘要失败的论文，包括已达到 `--max-failed-attempts` 的永久失败记录。
- 已成功获取摘要的论文仍然跳过，不会覆盖。

### `scripts/fetch_cvf_abstracts.py`
- 新增 `--force` 参数。
- 强制模式下会重试之前 `tried` 但未 `filled` 的 CVF URL。
- 已在 `filled_set` 中的 URL 仍然跳过，不会覆盖。


## 注意

- `force` 建议仅偶尔手动使用。多次执行强制模式会反复尝试同一批永久失败的论文，可能消耗 API 配额。
- 强制模式不会覆盖任何已有摘要。