### PR TITLE
feat: add Baidu Analytics support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,12 +62,16 @@ PAPERVAULT_HF_REPO_ID=youngfish42/papervault-cache
 # GUNICORN_KEEPALIVE=5
 
 # -----------------------------------------------------------------------------
-# Google Analytics / Search Console (optional; container runtime variables)
+# Google Analytics / Search Console / Baidu Tongji (optional; container runtime variables)
 # -----------------------------------------------------------------------------
 # GA4 web data-stream measurement ID, for example: G-XXXXXXXXXX
 # Injected into the SPA by docker/entrypoint.sh at container start, so changing
 # the value only requires `docker compose up -d` again -- no image rebuild.
 # GOOGLE_ANALYTICS_ID=G-XXXXXXXXXX
+
+# Baidu Tongji site ID, for example: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# Injected into the SPA by docker/entrypoint.sh at container start.
+# BAIDU_ANALYTICS_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Only the content token from Search Console's google-site-verification meta tag.
 # GOOGLE_SITE_VERIFICATION=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ COPY web-vue/package.json web-vue/package-lock.json ./
 RUN npm ci --no-audit --no-fund
 
 COPY web-vue/ ./
+ARG VITE_GOOGLE_ANALYTICS_ID
+ARG VITE_GOOGLE_SITE_VERIFICATION
+ARG VITE_BAIDU_ANALYTICS_ID
 RUN npm run build
 
 

--- a/README.en.md
+++ b/README.en.md
@@ -130,13 +130,17 @@ The image uses a multi-stage build: Node.js compiles the Vue frontend, then Guni
 docker build \
   --build-arg VITE_GOOGLE_ANALYTICS_ID=G-XXXXXXXXXX \
   --build-arg VITE_GOOGLE_SITE_VERIFICATION=xxxxxxxxxxxxxxxx \
+  --build-arg VITE_BAIDU_ANALYTICS_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
   -t papervault .
 docker run --rm -p 5001:5001 --env-file .env papervault
 ```
 
 Open `http://127.0.0.1:5001` after startup. The health endpoint is `http://127.0.0.1:5001/api/v1/healthz`. Tune the server with `GUNICORN_WORKERS`, `GUNICORN_THREADS`, and `GUNICORN_TIMEOUT`; defaults are documented in `.env.example`.
 
-Google Analytics and Search Console are optional, and the committed production environment leaves both values unset. Without these build arguments, the app does not load GA or inject a site-verification tag. For non-Docker builds, export the same variables before running `npm run build`.
+Google Analytics, Search Console, and Baidu Analytics are optional, and the committed production environment leaves these values unset. Without these build arguments, the app does not load the corresponding scripts or inject a site-verification tag. For non-Docker builds, export the same variables before running `npm run build`.
+
+- Google Analytics: `VITE_GOOGLE_ANALYTICS_ID` (build-time) / `GOOGLE_ANALYTICS_ID` (container runtime).
+- Baidu Analytics: `VITE_BAIDU_ANALYTICS_ID` (build-time) / `BAIDU_ANALYTICS_ID` (container runtime).
 
 ## :open_book: Coverage
 

--- a/README.md
+++ b/README.md
@@ -130,13 +130,17 @@ Docker 镜像使用多阶段构建：先用 Node.js 编译 Vue 前端，再由 P
 docker build \
   --build-arg VITE_GOOGLE_ANALYTICS_ID=G-XXXXXXXXXX \
   --build-arg VITE_GOOGLE_SITE_VERIFICATION=xxxxxxxxxxxxxxxx \
+  --build-arg VITE_BAIDU_ANALYTICS_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
   -t papervault .
 docker run --rm -p 5001:5001 --env-file .env papervault
 ```
 
 启动后访问 `http://127.0.0.1:5001`，健康检查地址为 `http://127.0.0.1:5001/api/v1/healthz`。可通过 `GUNICORN_WORKERS`、`GUNICORN_THREADS` 和 `GUNICORN_TIMEOUT` 调整服务参数；默认值见 `.env.example`。
 
-Google Analytics 与 Search Console 均为可选项，仓库提交的生产环境配置不会设置这两个值：不传上述构建参数时不会加载 GA，也不会注入站点验证标签。非 Docker 构建可在运行 `npm run build` 前导出同名环境变量。
+Google Analytics、Search Console 与 Baidu Analytics 均为可选项，仓库提交的生产环境配置不会设置这些值：不传上述构建参数时不会加载对应脚本，也不会注入站点验证标签。非 Docker 构建可在运行 `npm run build` 前导出同名环境变量。
+
+- Google Analytics：`VITE_GOOGLE_ANALYTICS_ID`（构建时）/ `GOOGLE_ANALYTICS_ID`（容器运行时）。
+- Baidu Analytics：`VITE_BAIDU_ANALYTICS_ID`（构建时）/ `BAIDU_ANALYTICS_ID`（容器运行时）。
 
 ## :open_book: 收录会议范围
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,12 +6,19 @@ set -eu
 INDEX="/app/static/dist/index.html"
 GA_ID="${GOOGLE_ANALYTICS_ID:-}"
 SITE_VERIFICATION="${GOOGLE_SITE_VERIFICATION:-}"
+BA_ID="${BAIDU_ANALYTICS_ID:-}"
 
 if [ -f "$INDEX" ]; then
   if [ -n "$GA_ID" ]; then
     sed -i "s/__GA_ID__/$GA_ID/g" "$INDEX"
   else
     sed -i 's/__GA_ID__//g' "$INDEX"
+  fi
+
+  if [ -n "$BA_ID" ]; then
+    sed -i "s/__BA_ID__/$BA_ID/g" "$INDEX"
+  else
+    sed -i 's/__BA_ID__//g' "$INDEX"
   fi
 
   if [ -n "$SITE_VERIFICATION" ]; then

--- a/web-vue/env.d.ts
+++ b/web-vue/env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_GOOGLE_ANALYTICS_ID?: string
+  readonly VITE_BAIDU_ANALYTICS_ID?: string
 }
 
 interface ImportMeta {

--- a/web-vue/index.html
+++ b/web-vue/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="google-site-verification" content="__GOOGLE_SITE_VERIFICATION__" data-runtime-config />
     <script>window.__PAPERVAULT_GA_ID__ = "__GA_ID__"</script>
+    <script>window.__PAPERVAULT_BA_ID__ = "__BA_ID__"</script>
     <title>PaperVault</title>
   </head>
   <body>

--- a/web-vue/src/main.ts
+++ b/web-vue/src/main.ts
@@ -10,6 +10,7 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
 import ElementIcons from './icons/element-icons'
+import { installBaiduAnalytics } from './utils/baiduAnalytics'
 import { installGoogleAnalytics } from './utils/googleAnalytics'
 import 'element-plus/theme-chalk/dark/css-vars.css'
 import 'element-plus/theme-chalk/el-loading.css'
@@ -20,6 +21,7 @@ import './assets/main.css'
 const app = createApp(App)
 
 installGoogleAnalytics(router)
+installBaiduAnalytics(router)
 app.use(router)
 app.use(ElementIcons)
 app.mount('#app')

--- a/web-vue/src/utils/baiduAnalytics.ts
+++ b/web-vue/src/utils/baiduAnalytics.ts
@@ -1,0 +1,44 @@
+import { nextTick } from 'vue'
+import type { Router } from 'vue-router'
+
+declare global {
+  interface Window {
+    // Baidu Tongji tracker queue.
+    _hmt: unknown[]
+    // Injected at container start by docker/entrypoint.sh (see index.html placeholder).
+    __PAPERVAULT_BA_ID__?: string
+  }
+}
+
+function trackPageView() {
+  window._hmt.push(['_trackPageview', window.location.href])
+}
+
+export function installBaiduAnalytics(router: Router) {
+  if (typeof window === 'undefined') return
+
+  const rawTrackingId =
+    window.__PAPERVAULT_BA_ID__ || import.meta.env.VITE_BAIDU_ANALYTICS_ID || ''
+  const trackingId = rawTrackingId === '__BA_ID__' ? '' : rawTrackingId.trim()
+
+  if (!trackingId) return
+
+  window._hmt = window._hmt || []
+
+  const script = document.createElement('script')
+  script.async = true
+  script.src = `https://hm.baidu.com/hm.js?${encodeURIComponent(trackingId)}`
+  document.head.appendChild(script)
+
+  // hm.js 在加载时会自动上报当前页面，因此跳过首次导航，避免 PV 重复计数。
+  let isFirstNavigation = true
+  router.afterEach(async (_to, _from, failure) => {
+    if (failure) return
+    await nextTick()
+    if (isFirstNavigation) {
+      isFirstNavigation = false
+      return
+    }
+    trackPageView()
+  })
+}

--- a/web-vue/src/utils/googleAnalytics.ts
+++ b/web-vue/src/utils/googleAnalytics.ts
@@ -10,10 +10,6 @@ declare global {
   }
 }
 
-const measurementId = (
-  window.__PAPERVAULT_GA_ID__ || import.meta.env.VITE_GOOGLE_ANALYTICS_ID || ''
-).trim()
-
 function trackPageView() {
   window.gtag('event', 'page_view', {
     page_title: document.title,
@@ -22,7 +18,16 @@ function trackPageView() {
 }
 
 export function installGoogleAnalytics(router: Router) {
-  if (!measurementId || typeof window === 'undefined') return
+  if (typeof window === 'undefined') return
+
+  const rawMeasurementId =
+    window.__PAPERVAULT_GA_ID__ ||
+    import.meta.env.VITE_GOOGLE_ANALYTICS_ID ||
+    ''
+  const measurementId =
+    rawMeasurementId === '__GA_ID__' ? '' : rawMeasurementId.trim()
+
+  if (!measurementId) return
 
   window.dataLayer = window.dataLayer || []
   window.gtag =


### PR DESCRIPTION
Mirror the existing Google Analytics integration:
- Add web-vue/src/utils/baiduAnalytics.ts with router-driven pageview tracking.
- Read tracking ID from VITE_BAIDU_ANALYTICS_ID build arg or the window.__PAPERVAULT_BA_ID__ runtime placeholder.
- Inject placeholder in index.html and replace it via docker/entrypoint.sh using BAIDU_ANALYTICS_ID env var.
- Declare missing VITE_* build args in Dockerfile so build-time injection for both GA and Baidu works as documented.
- Update .env.example, README.md and README.en.md with Baidu Analytics instructions.
- Fix placeholder-leakage in dev mode for both GA and Baidu: treat the literal strings '__GA_ID__' / '__BA_ID__' as unset so analytics scripts are not loaded when the placeholder is not replaced.