### PR TITLE
Release prep/security frontend fixes

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,12 +1,15 @@
 <p align="center">
-<h1 align="center"> <img src="./pics/icon/ai.png" width="30" /> PaperVault</h1>
+<h1 align="center"> <a href="https://papervault.top"><img src="./pics/icon/ai.png" width="30" /> PaperVault</a></h1>
 </p>
 <p align="center">
   <strong>English</strong> | <a href="README.md">简体中文</a>
 </p>
+<p align="center">
+  🌐 Live site：<a href="https://papervault.top"><strong>papervault.top</strong></a>
+</p>
 
 <p align="center">
-  <img src="./pics/screenshot/web.en.jpg" alt="PaperVault web search UI" width="850" />
+  <a href="https://papervault.top"><img src="./pics/screenshot/web.en.jpg" alt="PaperVault web search UI" width="850" /></a>
 </p>
 
 ## :jack_o_lantern: Project Introduction

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 <p align="center">
-<h1 align="center"> <img src="./pics/icon/ai.png" width="30" /> PaperVault</h1>
+<h1 align="center"> <a href="https://papervault.top"><img src="./pics/icon/ai.png" width="30" /> PaperVault</a></h1>
 </p>
 <p align="center">
   <a href="README.en.md">English</a> | <strong>简体中文</strong>
 </p>
+<p align="center">
+  🌐 线上访问：<a href="https://papervault.top"><strong>papervault.top</strong></a>
+</p>
 
 <p align="center">
-  <img src="./pics/screenshot/web.jpg" alt="PaperVault Web 检索界面" width="850" />
+  <a href="https://papervault.top"><img src="./pics/screenshot/web.jpg" alt="PaperVault Web 检索界面" width="850" /></a>
 </p>
 
 ## :jack_o_lantern: 项目简介

--- a/docs/HF_README.md
+++ b/docs/HF_README.md
@@ -31,6 +31,8 @@ configs:
 PaperVault 是一份**持续自动更新**的统一论文元数据库，覆盖自然语言处理、计算机视觉、机器学习、数据挖掘、数据库、语音、系统、网络、安全、理论计算机科学、人机交互、计算机图形学与多媒体等方向的顶级会议与期刊。PaperVault is a **continuously-updated, unified metadata database** of papers from top-tier conferences and journals across NLP, Computer Vision, Machine Learning, Data Mining, Databases, Speech, Systems, Networking, Security, Theory, HCI, Graphics, and Multimedia.
 
 > 🌐 源仓库 / Source: **[github.com/youngfish42/PaperVault](https://github.com/youngfish42/PaperVault)** — Web UI、REST API、采集流水线、Issues / PRs 全部在那里 · Web UI, REST API, crawling pipelines and issues/PRs all live there.
+>
+> 🌐 在线搜索 / Live search: **[papervault.top](https://papervault.top)** — 直接使用 Web 检索界面，无需下载数据 · Use the web search UI directly without downloading the dataset.
 
 ---
 
@@ -146,6 +148,15 @@ huggingface-cli download youngfish42/PaperVault \
 | `update_readme` | 仅手动触发 (`workflow_dispatch`) · Manual only (`workflow_dispatch`) | 默认仅刷新 README 与统计；当输入参数 `mode=force` 时执行全量重建 · Refreshes the README and statistics by default; performs a full rebuild only when invoked with `mode=force` |
 
 每次推送都使用 Hugging Face 的 `parent_commit` 乐观锁机制，避免并发覆盖。Each push uses Hugging Face's `parent_commit` optimistic-lock mechanism to avoid silently overwriting concurrent updates.
+
+---
+
+## 🌐 线上服务 · Live Service
+
+无需下载数据集即可直接体验 Web 检索：
+No need to download the dataset — try the web search directly:
+
+👉 **[papervault.top](https://papervault.top)**
 
 ---
 

--- a/web-vue/package-lock.json
+++ b/web-vue/package-lock.json
@@ -2068,9 +2068,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4797,9 +4797,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -6572,9 +6572,9 @@
       }
     },
     "node_modules/unplugin-auto-import/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6646,9 +6646,9 @@
       }
     },
     "node_modules/unplugin-vue-components/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web-vue/package.json
+++ b/web-vue/package.json
@@ -42,7 +42,8 @@
     "vue-tsc": "^3.3.2"
   },
   "overrides": {
-    "brace-expansion@>=2.0.0 <2.1.2": "^2.1.2",
-    "brace-expansion@>=1.0.0 <1.1.16": "^1.1.16"
+    "brace-expansion@>=2.0.0 <2.1.4": "^2.1.4",
+    "brace-expansion@>=1.0.0 <1.1.18": "^1.1.18",
+    "nanoid": "^3.3.18"
   }
 }

--- a/web-vue/src/components/AiSuggestSection.vue
+++ b/web-vue/src/components/AiSuggestSection.vue
@@ -181,6 +181,8 @@ const handleTest = async (): Promise<void> => {
       </div>
     </template>
 
+    <p class="pv-ai-description">{{ t('settings.aiSuggest.description') }}</p>
+
     <el-form :label-position="'top'" class="pv-ai-form">
       <el-form-item :label="t('settings.aiSuggest.form.provider')">
         <el-select v-model="form.provider" filterable style="width: 100%">
@@ -191,6 +193,9 @@ const handleTest = async (): Promise<void> => {
             :value="p.key"
           />
         </el-select>
+        <div class="pv-ai-hint">
+          {{ t('settings.aiSuggest.hint.provider') }}
+        </div>
         <div v-if="preset?.note" class="pv-ai-hint">{{ preset.note }}</div>
       </el-form-item>
 
@@ -280,6 +285,9 @@ const handleTest = async (): Promise<void> => {
     <h3 class="pv-ai-test-title">
       {{ t('settings.aiSuggest.test.title') }}
     </h3>
+    <p class="pv-ai-test-description">
+      {{ t('settings.aiSuggest.test.description') }}
+    </p>
     <div class="pv-ai-test-row">
       <el-input
         v-model="testQuery"
@@ -341,6 +349,21 @@ const handleTest = async (): Promise<void> => {
   font-size: 12px;
   font-weight: 600;
   color: var(--el-color-success, #67c23a);
+}
+.pv-settings-card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--el-text-color-primary, #303133);
+}
+.pv-ai-description,
+.pv-ai-test-description {
+  font-size: 13.5px;
+  line-height: 1.7;
+  color: var(--el-text-color-regular, #4c4d4f);
+  margin: 0 0 16px;
+}
+.pv-ai-test-description {
+  margin: 0 0 10px;
 }
 .pv-ai-form :deep(.el-form-item) {
   margin-bottom: 14px;

--- a/web-vue/src/utils/i18n.ts
+++ b/web-vue/src/utils/i18n.ts
@@ -92,8 +92,10 @@ const messages: Record<Lang, Record<string, string>> = {
     'toolbar.settings': '设置',
     'settings.pageTitle': '设置',
     'settings.intro':
-      '配置 LLM 提供方、API 密钥和默认参数。设置仅保存在本地，不会上传。',
+      '本页配置「AI 关键词推荐」与「AI 结果重排」所需的 LLM 提供方、API 密钥和默认参数。除 API 密钥保存在会话中（关闭浏览器即清除）外，其余设置保存在浏览器本地；留空时将使用服务端默认环境变量。',
     'settings.aiSuggest.title': 'AI 关键词推荐',
+    'settings.aiSuggest.description':
+      '下方的参数会用于首页搜索框的「AI 搜索」按钮，以及搜索结果右侧的 AI 推荐面板。选择提供方后会自动填入默认接口地址、模型与协议；你可以在此基础上修改，也可以完全留空以使用服务端默认配置。',
     'settings.aiSuggest.form.provider': '提供方',
     'settings.aiSuggest.form.baseUrl': '接口地址',
     'settings.aiSuggest.form.model': '模型',
@@ -108,16 +110,17 @@ const messages: Record<Lang, Record<string, string>> = {
     'settings.aiSuggest.saved': '✓ 已保存',
     'settings.aiSuggest.hint.apiKey':
       '密钥仅存于本会话（关闭浏览器即清除），不会上传到服务器。',
-    'settings.aiSuggest.test.title': '测一下',
+    'settings.aiSuggest.hint.provider':
+      '选择提供方后会自动填入默认接口地址、模型与协议，你仍可手动修改。',
+    'settings.aiSuggest.test.title': '功能测试',
+    'settings.aiSuggest.test.description':
+      '输入一段研究描述，点击「生成关键词」，验证当前配置能否正常调用 LLM。',
     'settings.aiSuggest.test.queryPh': '输入一段描述…',
     'settings.aiSuggest.test.button': '生成关键词',
     'settings.aiSuggest.test.empty': '暂无返回关键词',
     'settings.aiSuggest.test.errorQuery': '请输入测试用的查询内容',
     'settings.aiSuggest.test.errorProvider': '请先选择提供方',
     'settings.aiSuggest.test.errorUnknown': '请求失败',
-    'settings.about.title': '关于此页面',
-    'settings.about.body':
-      '本页是 P2-C 阶段交付的设置面板外壳，负责承载 P2-D 接入的 AI 提供方配置、模型选择与默认参数。',
     'tips.title': '搜索小贴士',
     'tips.desc':
       '① 直接输入关键词即可，默认按主题（标题 + 摘要 + 关键词）匹配；② 可使用 Web of Science 风格语法精确限定字段，如 AU="Yang Liu" SO=ICLR,NeurIPS PY=2023-2026；③ 想要可视化组合多条件？点击「高级搜索」打开行式表单，自动生成检索式；④ 点击作者名可一键检索其所有论文。',
@@ -274,8 +277,10 @@ const messages: Record<Lang, Record<string, string>> = {
     'toolbar.settings': 'Settings',
     'settings.pageTitle': 'Settings',
     'settings.intro':
-      'Configure the LLM provider, API key, and defaults. Settings live in your browser only.',
+      'Configure the LLM provider, API key, and defaults used by AI keyword suggestions and AI result reranking. The API key is kept in this session only (wiped when the browser closes); everything else is stored locally in your browser. Leave fields empty to fall back to the server-side defaults.',
     'settings.aiSuggest.title': 'AI keyword suggestions',
+    'settings.aiSuggest.description':
+      'These parameters are used by the AI Search button on the home page and the AI suggestion panel in the result list. Picking a provider auto-fills the default endpoint, model, and protocol; you can still edit them, or leave everything empty to use the server defaults.',
     'settings.aiSuggest.form.provider': 'Provider',
     'settings.aiSuggest.form.baseUrl': 'Endpoint URL',
     'settings.aiSuggest.form.model': 'Model',
@@ -290,16 +295,17 @@ const messages: Record<Lang, Record<string, string>> = {
     'settings.aiSuggest.saved': '✓ Saved',
     'settings.aiSuggest.hint.apiKey':
       'Key lives only in this session (wiped on browser close) and is never sent to our servers.',
-    'settings.aiSuggest.test.title': 'Test it',
+    'settings.aiSuggest.hint.provider':
+      'Picking a provider auto-fills the default endpoint, model, and protocol; you can still edit them.',
+    'settings.aiSuggest.test.title': 'Test connection',
+    'settings.aiSuggest.test.description':
+      'Enter a research description and click Generate to verify that the current settings can reach the LLM.',
     'settings.aiSuggest.test.queryPh': 'Enter a description…',
     'settings.aiSuggest.test.button': 'Generate',
     'settings.aiSuggest.test.empty': 'No keywords returned',
     'settings.aiSuggest.test.errorQuery': 'Please enter a query to test',
     'settings.aiSuggest.test.errorProvider': 'Please pick a provider first',
     'settings.aiSuggest.test.errorUnknown': 'Request failed',
-    'settings.about.title': 'About this page',
-    'settings.about.body':
-      'This page is the P2-C settings panel shell. It will host the P2-D AI provider configuration, model selection, and default-parameter controls.',
     'tips.title': 'Search Tips',
     'tips.desc':
       '① Just type keywords — the default Topic search matches title + abstract + author keywords. ② Use Web of Science style field tags for precision, e.g. AU="Yang Liu" SO=ICLR,NeurIPS PY=2023-2026. ③ Need a visual builder? Open "Advanced search" to add rows and auto-generate the expression. ④ Click any author name to instantly list all their papers.',

--- a/web-vue/src/views/SettingsView.vue
+++ b/web-vue/src/views/SettingsView.vue
@@ -5,9 +5,13 @@ import MainNavBar from '@/components/MainNavBar.vue'
 import { useI18n } from '@/utils/i18n'
 
 /**
- * P2-C Settings page shell + P2-D AI Suggest section. The AI Suggest
- * card (``<AiSuggestSection />``) replaces the P2-C ``<el-alert>``
- * placeholder and consumes P2-B's settings + API wrappers end-to-end.
+ * Settings page for PaperVault.
+ *
+ * Lets users configure the LLM provider, API key, and defaults used by the
+ * AI keyword suggestion dialog on the home page, the AI suggestion panel
+ * in search results, and AI-powered result reranking. All values are kept
+ * in browser storage (localStorage for non-secrets, sessionStorage for the
+ * API key) and are never uploaded to our servers.
  */
 
 const isDark = useDark()
@@ -28,15 +32,6 @@ const { t } = useI18n()
       <p class="pv-settings-intro">{{ t('settings.intro') }}</p>
 
       <AiSuggestSection />
-
-      <el-card shadow="never" class="pv-settings-card">
-        <template #header>
-          <span class="pv-settings-card-title">
-            {{ t('settings.about.title') }}
-          </span>
-        </template>
-        <p class="pv-settings-about-body">{{ t('settings.about.body') }}</p>
-      </el-card>
     </section>
   </main>
 </template>
@@ -64,16 +59,5 @@ const { t } = useI18n()
   border: 1px solid var(--el-border-color-lighter, #ebeef5);
   border-radius: 10px;
   background: var(--el-bg-color, #fff);
-}
-.pv-settings-card-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--el-text-color-primary, #303133);
-}
-.pv-settings-about-body {
-  font-size: 13.5px;
-  line-height: 1.7;
-  color: var(--el-text-color-regular, #4c4d4f);
-  margin: 0;
 }
 </style>


### PR DESCRIPTION
## 变更概要

本分支汇总了网站正式上线前的前端安全修复、文档入口补充与设置页体验优化。

## 主要变更

### 1. 前端依赖安全修复
- 在 `web-vue/package.json` 的 `overrides` 中强制 `nanoid` 升级到 `3.3.18`，修复其 `customAlphabet/customRandom` 在 `size=0` 时的无限循环 DoS 漏洞。
- 同步更新 `brace-expansion` 的覆盖规则到 `^1.1.18` / `^2.1.4`，消除 npm audit 报告的高危漏洞。
- 验证：`npm audit` 0 漏洞，`type-check` 与 `lint:check` 均通过。

### 2. README 与 Hugging Face 版 README 增加线上入口
- `README.md` / `README.en.md`：项目标题与项目截图均改为可点击跳转至 papervault.top，并在语言切换行下方新增居中线上访问提示。
- `docs/HF_README.md`：在项目简介引用块中补充「在线搜索」入口，并新增独立的「线上服务 · Live Service」小节。

### 3. 设置页冗余清理与文案优化
- 移除 `SettingsView.vue` 中冗余的「关于此页面」卡片及其内部 P2-C/P2-D 阶段文案。
- 重写页面总览说明，明确告知用户该页配置用于「AI 关键词推荐」与「AI 结果重排」，API 密钥仅存会话、其余设置存在本地，留空时使用服务端默认环境变量。
- 在 AI 推荐卡片内新增功能说明、提供方下拉提示、测试区说明，提升设置页的可理解性。
- 修复 `.pv-settings-card-title` 样式作用域问题。

## 测试验证
- `npm run type-check` 通过
- `npm run lint:check` 通过
- `npm audit` 无漏洞

## 注意事项
- README 中新增链接位于 `maintain.py` 自动替换标记之外，后续统计刷新不会被覆盖。
- 本次提交未改动任何后端业务逻辑或数据采集流程。