### PR TITLE
fix: deploy Baidu Analytics snippet correctly in SPA head

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,6 +62,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VITE_GOOGLE_ANALYTICS_ID=${{ vars.VITE_GOOGLE_ANALYTICS_ID }}
+            VITE_GOOGLE_SITE_VERIFICATION=${{ vars.VITE_GOOGLE_SITE_VERIFICATION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -82,6 +85,7 @@ jobs:
               echo "HF_TOKEN=$HF_TOKEN"
               echo "PAPERVAULT_HF_REPO_ID=youngfish42/PaperVault"
               echo "GOOGLE_ANALYTICS_ID=${{ vars.VITE_GOOGLE_ANALYTICS_ID }}"
+              echo "BAIDU_ANALYTICS_ID=${{ vars.VITE_BAIDU_ANALYTICS_ID }}"
               echo "GOOGLE_SITE_VERIFICATION=${{ vars.VITE_GOOGLE_SITE_VERIFICATION }}"
             } > .env
             chmod 600 .env

--- a/web-vue/index.html
+++ b/web-vue/index.html
@@ -6,8 +6,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="google-site-verification" content="__GOOGLE_SITE_VERIFICATION__" data-runtime-config />
     <script>window.__PAPERVAULT_GA_ID__ = "__GA_ID__"</script>
-    <script>window.__PAPERVAULT_BA_ID__ = "__BA_ID__"</script>
     <title>PaperVault</title>
+    <script>
+      (function () {
+        var baiduId = "__BA_ID__";
+        if (!baiduId || baiduId === "__BA_ID__") return;
+        window._hmt = window._hmt || [];
+        var hm = document.createElement("script");
+        hm.src = "https://hm.baidu.com/hm.js?" + encodeURIComponent(baiduId);
+        var s = document.getElementsByTagName("script")[0];
+        s.parentNode.insertBefore(hm, s);
+      })();
+    </script>
   </head>
   <body>
     <div id="app">

--- a/web-vue/index.html
+++ b/web-vue/index.html
@@ -6,8 +6,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="google-site-verification" content="__GOOGLE_SITE_VERIFICATION__" data-runtime-config />
     <script>window.__PAPERVAULT_GA_ID__ = "__GA_ID__"</script>
-    <script>window.__PAPERVAULT_BA_ID__ = "__BA_ID__"</script>
     <title>PaperVault</title>
+    <script>
+      (function () {
+        var baiduId = "__BA_ID__";
+        if (!baiduId || baiduId === "__BA_ID__") return;
+        var _hmt = _hmt || [];
+        var hm = document.createElement("script");
+        hm.src = "https://hm.baidu.com/hm.js?" + encodeURIComponent(baiduId);
+        var s = document.getElementsByTagName("script")[0];
+        s.parentNode.insertBefore(hm, s);
+      })();
+    </script>
   </head>
   <body>
     <div id="app">

--- a/web-vue/src/utils/baiduAnalytics.ts
+++ b/web-vue/src/utils/baiduAnalytics.ts
@@ -3,10 +3,8 @@ import type { Router } from 'vue-router'
 
 declare global {
   interface Window {
-    // Baidu Tongji tracker queue.
+    // Baidu Tongji tracker queue, initialised by the inline snippet in index.html.
     _hmt: unknown[]
-    // Injected at container start by docker/entrypoint.sh (see index.html placeholder).
-    __PAPERVAULT_BA_ID__?: string
   }
 }
 
@@ -14,23 +12,14 @@ function trackPageView() {
   window._hmt.push(['_trackPageview', window.location.href])
 }
 
+/**
+ * Hooks into Vue Router to report page views for SPA navigation.
+ * The Baidu Tongji hm.js script is loaded by the inline snippet in index.html,
+ * which already reports the initial page load, so we skip the first navigation.
+ */
 export function installBaiduAnalytics(router: Router) {
-  if (typeof window === 'undefined') return
+  if (typeof window === 'undefined' || !Array.isArray(window._hmt)) return
 
-  const rawTrackingId =
-    window.__PAPERVAULT_BA_ID__ || import.meta.env.VITE_BAIDU_ANALYTICS_ID || ''
-  const trackingId = rawTrackingId === '__BA_ID__' ? '' : rawTrackingId.trim()
-
-  if (!trackingId) return
-
-  window._hmt = window._hmt || []
-
-  const script = document.createElement('script')
-  script.async = true
-  script.src = `https://hm.baidu.com/hm.js?${encodeURIComponent(trackingId)}`
-  document.head.appendChild(script)
-
-  // hm.js 在加载时会自动上报当前页面，因此跳过首次导航，避免 PV 重复计数。
   let isFirstNavigation = true
   router.afterEach(async (_to, _from, failure) => {
     if (failure) return


### PR DESCRIPTION
- Inline the official Baidu Tongji snippet in web-vue/index.html right before </head>, using __BA_ID__ placeholder for runtime injection.
- Remove the dynamic <script async> injection from baiduAnalytics.ts; keep only the Vue Router page-view tracking to avoid double-counting the initial load.
- Pass VITE_BAIDU_ANALYTICS_ID as a Docker build-arg and write BAIDU_ANALYTICS_ID into the deployed .env so docker/entrypoint.sh can replace the placeholder.

This fixes the Baidu Tongji dashboard reporting that the tracking code was not properly deployed.