### PR TITLE
fix(discovery): inherit unmerged discoveries from auto-discover-confs…

### DIFF
--- a/.github/workflows/discover_and_update.yml
+++ b/.github/workflows/discover_and_update.yml
@@ -3,6 +3,11 @@ name: Discover and Update Conference Configs
 env:
   PYTHON_VERSION: "3.10"
 
+concurrency:
+  # 防止多个 discover 实例并发读写 auto-discover-confs 分支，避免竞态覆盖未合并发现
+  group: papervault-discover
+  cancel-in-progress: false
+
 on:
   schedule:
     # 每天北京时间 02:00 (UTC 18:00) 运行 
@@ -76,7 +81,7 @@ jobs:
           if [ -n "${{ github.event.inputs.end_year }}" ]; then
             END_ARG="--end-year ${{ github.event.inputs.end_year }}"
           fi
-          python -m discovery.generate_conf $START_ARG $END_ARG --soft-timeout 18000
+          python -m discovery.generate_conf $START_ARG $END_ARG --soft-timeout 18000 --inherit-branch auto-discover-confs
           echo "changed=$(git diff --name-only -- conf/ | wc -l)" >> "$GITHUB_OUTPUT"
 
       - name: Setup GIT user

--- a/discovery/generate_conf.py
+++ b/discovery/generate_conf.py
@@ -92,13 +92,31 @@ def merge_conf(existing: list, new: list, key: str = "url") -> list:
     return merged
 
 
+class InheritBranchError(RuntimeError):
+    """继承未合并发现分支失败且不应静默降级时抛出。"""
+
+
 def _git_cwd_args() -> list:
     """返回让 git 在 conf/ 所在仓库根目录执行所需的 -C 参数列表。"""
     return ["-C", str(CONF_DIR.parent)]
 
 
+def _git_run(args: list, **kwargs) -> subprocess.CompletedProcess:
+    """在仓库根目录运行 git 命令，返回 CompletedProcess（含 stdout/stderr）。"""
+    return subprocess.run(
+        ["git", *_git_cwd_args(), *args],
+        capture_output=True,
+        text=True,
+        **kwargs,
+    )
+
+
 def _load_conf_from_ref(ref: str, filename: str) -> list:
-    """从指定 git 引用读取 conf 文件内容（失败返回空列表）。"""
+    """从指定 git 引用读取 conf 文件内容。
+
+    - 引用/文件不存在：返回空列表（可接受，首次运行）。
+    - 超时或其它意外错误：抛出 InheritBranchError，避免静默降级。
+    """
     try:
         output = subprocess.check_output(
             ["git", *_git_cwd_args(), "show", f"{ref}:{CONF_DIR.name}/{filename}"],
@@ -106,34 +124,63 @@ def _load_conf_from_ref(ref: str, filename: str) -> list:
             timeout=30,
         )
         return json.loads(output.decode("utf-8"))
-    except Exception:
+    except subprocess.TimeoutExpired as exc:
+        raise InheritBranchError(
+            f"git show {ref}:{CONF_DIR.name}/{filename} timed out after {exc.timeout}s; "
+            "refusing to continue to avoid overwriting unmerged discoveries"
+        ) from exc
+    except subprocess.CalledProcessError:
+        # 引用不存在或文件在该引用中不存在，属于正常情况
         return []
+    except json.JSONDecodeError as exc:
+        raise InheritBranchError(
+            f"Invalid JSON in {ref}:{CONF_DIR.name}/{filename}: {exc}; "
+            "refusing to continue to avoid overwriting unmerged discoveries"
+        ) from exc
+
+
+def _has_local_ref(branch: str) -> bool:
+    """检查本地是否存在指定分支/引用。"""
+    result = _git_run(["rev-parse", "--verify", branch], timeout=10)
+    return result.returncode == 0
+
+
+def _has_origin_remote() -> bool:
+    """检查仓库是否配置了 origin 远程。"""
+    result = _git_run(["remote", "get-url", "origin"], timeout=10)
+    return result.returncode == 0
 
 
 def _resolve_inherit_refs(branch: str) -> list:
     """把用户提供的 branch 参数解析成候选 git 引用列表。
 
+    策略：
     - 若参数本身已是完整 ref（如 origin/auto-discover-confs），直接返回。
-    - 否则先尝试 origin/<branch>；若解析失败再回落到本地 <branch>。
-      在 CI 环境中会先执行 git fetch origin <branch> 来确保远程引用存在。
+    - 若本地存在该分支，直接使用本地引用，避免不必要的网络 fetch。
+    - 否则若仓库配置了 origin 远程，先执行 git fetch origin <branch>；
+      fetch 失败视为异常，直接抛出 InheritBranchError 终止流程（fail-fast），
+      防止 create-pull-request 在保护未生效时覆盖未合并发现。
+    - 无 origin 远程且本地无该分支时，返回 [branch]，由调用方按“不存在”降级。
     """
     if "/" in branch:
         return [branch]
 
-    refs = [f"origin/{branch}", branch]
+    if _has_local_ref(branch):
+        return [branch]
 
-    # 在 CI 中通常需要先从 origin fetch；本地测试/无 remote 时静默失败
-    try:
-        subprocess.run(
-            ["git", *_git_cwd_args(), "fetch", "origin", branch],
-            check=False,
-            capture_output=True,
-            timeout=60,
+    if not _has_origin_remote():
+        # 本地开发/测试环境没有 origin，直接尝试本地引用名称
+        return [branch]
+
+    result = _git_run(["fetch", "origin", branch], timeout=60)
+    if result.returncode != 0:
+        stderr = result.stderr.strip() if result.stderr else "(no stderr)"
+        raise InheritBranchError(
+            f"git fetch origin {branch} failed (rc={result.returncode}): {stderr}; "
+            "refusing to continue to avoid overwriting unmerged discoveries"
         )
-    except Exception:
-        pass
 
-    return refs
+    return [f"origin/{branch}", branch]
 
 
 def inherit_from_branch(branch: str, dry_run: bool = False):
@@ -275,14 +322,23 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-if __name__ == "__main__":
-    args = _build_parser().parse_args()
+def main(argv=None):
+    """命令行入口；被 ``if __name__ == "__main__"`` 调用，也可在测试中直接调用。"""
+    args = _build_parser().parse_args(argv)
 
-    run(
-        start_year=args.start_year,
-        end_year=args.end_year,
-        dry_run=args.dry_run,
-        only=args.only,
-        soft_timeout=args.soft_timeout,
-        inherit_branch=getattr(args, "inherit_branch"),
-    )
+    try:
+        run(
+            start_year=args.start_year,
+            end_year=args.end_year,
+            dry_run=args.dry_run,
+            only=args.only,
+            soft_timeout=args.soft_timeout,
+            inherit_branch=getattr(args, "inherit_branch"),
+        )
+    except InheritBranchError as e:
+        print(f"[!] {e}")
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/discovery/generate_conf.py
+++ b/discovery/generate_conf.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import re
+import subprocess
 import time
 from datetime import datetime
 from pathlib import Path
@@ -91,12 +92,94 @@ def merge_conf(existing: list, new: list, key: str = "url") -> list:
     return merged
 
 
+def _git_cwd_args() -> list:
+    """返回让 git 在 conf/ 所在仓库根目录执行所需的 -C 参数列表。"""
+    return ["-C", str(CONF_DIR.parent)]
+
+
+def _load_conf_from_ref(ref: str, filename: str) -> list:
+    """从指定 git 引用读取 conf 文件内容（失败返回空列表）。"""
+    try:
+        output = subprocess.check_output(
+            ["git", *_git_cwd_args(), "show", f"{ref}:{CONF_DIR.name}/{filename}"],
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+        )
+        return json.loads(output.decode("utf-8"))
+    except Exception:
+        return []
+
+
+def _resolve_inherit_refs(branch: str) -> list:
+    """把用户提供的 branch 参数解析成候选 git 引用列表。
+
+    - 若参数本身已是完整 ref（如 origin/auto-discover-confs），直接返回。
+    - 否则先尝试 origin/<branch>；若解析失败再回落到本地 <branch>。
+      在 CI 环境中会先执行 git fetch origin <branch> 来确保远程引用存在。
+    """
+    if "/" in branch:
+        return [branch]
+
+    refs = [f"origin/{branch}", branch]
+
+    # 在 CI 中通常需要先从 origin fetch；本地测试/无 remote 时静默失败
+    try:
+        subprocess.run(
+            ["git", *_git_cwd_args(), "fetch", "origin", branch],
+            check=False,
+            capture_output=True,
+            timeout=60,
+        )
+    except Exception:
+        pass
+
+    return refs
+
+
+def inherit_from_branch(branch: str, dry_run: bool = False):
+    """把指定分支上 conf/*.json 的未合并发现合并到当前工作区。
+
+    通过 git show 读取分支文件，使用 merge_conf() 按 url 去重合并，
+    避免直接 git merge 带来的冲突风险。
+    """
+    if not branch:
+        return
+
+    refs = _resolve_inherit_refs(branch)
+    print(f"[*] Inheriting unmerged conf entries from {branch}")
+
+    inherited_any = False
+    for path in sorted(CONF_DIR.glob("*.json")):
+        filename = path.name
+        branch_conf = []
+        for ref in refs:
+            branch_conf = _load_conf_from_ref(ref, filename)
+            if branch_conf:
+                break
+        if not branch_conf:
+            continue
+        inherited_any = True
+        existing = load_conf(filename)
+        merged = merge_conf(existing, branch_conf)
+        added = len(merged) - len(existing)
+        if added > 0:
+            if dry_run:
+                print(f"    + {filename}: would inherit {added} entries (dry-run)")
+            else:
+                save_conf(filename, merged)
+                print(f"    + {filename}: inherited {added} entries")
+
+    if not inherited_any:
+        print(f"    Branch/ref {branch} not found or contains no conf files; nothing to inherit.")
+
+
 def run(
     start_year: int = None,
     end_year: int = None,
     dry_run: bool = False,
     only: str = None,
     soft_timeout: float = None,
+    inherit_branch: str = None,
 ):
     if end_year is None:
         end_year = datetime.now().year
@@ -122,6 +205,11 @@ def run(
         if only and filename != only:
             continue
         grouped.setdefault(filename, []).append(cls)
+
+    # 若存在未合并的自动发现分支，先把其中的会议清单合并进来，
+    # 避免 create-pull-request 重置分支后覆盖旧发现。
+    if inherit_branch:
+        inherit_from_branch(inherit_branch, dry_run=dry_run)
 
     start_time = time.time()
 
@@ -174,7 +262,7 @@ def run(
             break
 
 
-if __name__ == "__main__":
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Auto-discover conference configs")
     parser.add_argument("--start-year", type=int, help="Start year (inclusive)")
     parser.add_argument("--end-year", type=int, help="End year (inclusive)")
@@ -182,7 +270,13 @@ if __name__ == "__main__":
     parser.add_argument("--only", type=str, help="Only process one conf file, e.g. acl_conf.json")
     parser.add_argument("--soft-timeout", type=float, default=None,
                         help="Soft timeout in seconds. Save progress and exit gracefully when reached (e.g. 18000 for 5h)")
-    args = parser.parse_args()
+    parser.add_argument("--inherit-branch", type=str, default=None,
+                        help="Inherit unmerged conf entries from this git branch/ref before discovering (e.g. auto-discover-confs)")
+    return parser
+
+
+if __name__ == "__main__":
+    args = _build_parser().parse_args()
 
     run(
         start_year=args.start_year,
@@ -190,4 +284,5 @@ if __name__ == "__main__":
         dry_run=args.dry_run,
         only=args.only,
         soft_timeout=args.soft_timeout,
+        inherit_branch=getattr(args, "inherit_branch"),
     )

--- a/discovery/generate_conf.py
+++ b/discovery/generate_conf.py
@@ -157,9 +157,12 @@ def _resolve_inherit_refs(branch: str) -> list:
     策略：
     - 若参数本身已是完整 ref（如 origin/auto-discover-confs），直接返回。
     - 若本地存在该分支，直接使用本地引用，避免不必要的网络 fetch。
-    - 否则若仓库配置了 origin 远程，先执行 git fetch origin <branch>；
-      fetch 失败视为异常，直接抛出 InheritBranchError 终止流程（fail-fast），
-      防止 create-pull-request 在保护未生效时覆盖未合并发现。
+    - 否则若仓库配置了 origin 远程，先执行 git fetch origin <branch>。
+      - fetch 因 "couldn't find remote ref" 失败：远程尚无该分支（首次运行）
+        或已删除，属于合法场景，返回 [f"origin/{branch}", branch] 优雅降级。
+      - fetch 因网络/远端/权限等其它原因失败：抛出 InheritBranchError 终止
+        流程（fail-fast），防止 create-pull-request 在保护未生效时覆盖
+        未合并发现。
     - 无 origin 远程且本地无该分支时，返回 [branch]，由调用方按“不存在”降级。
     """
     if "/" in branch:
@@ -175,6 +178,10 @@ def _resolve_inherit_refs(branch: str) -> list:
     result = _git_run(["fetch", "origin", branch], timeout=60)
     if result.returncode != 0:
         stderr = result.stderr.strip() if result.stderr else "(no stderr)"
+        # "couldn't find remote ref" 表示远程尚未创建该分支（首次运行）
+        # 或该分支已被合并删除，属于合法场景，优雅降级。
+        if "couldn't find remote ref" in stderr:
+            return [f"origin/{branch}", branch]
         raise InheritBranchError(
             f"git fetch origin {branch} failed (rc={result.returncode}): {stderr}; "
             "refusing to continue to avoid overwriting unmerged discoveries"

--- a/discovery/generate_conf.py
+++ b/discovery/generate_conf.py
@@ -104,10 +104,11 @@ def _git_cwd_args() -> list:
 def _git_run(args: list, **kwargs) -> subprocess.CompletedProcess:
     """在仓库根目录运行 git 命令，返回 CompletedProcess（含 stdout/stderr）。
 
-    固定 LC_ALL=C，避免 git 的 fatal 消息随 locale 本地化，确保下游对
-    stderr 文本的匹配在所有环境中一致。
+    固定 LC_ALL=C 并将 LANGUAGE 置空，避免 git 的 fatal 消息随 locale 本地化。
+    GNU gettext 优先级为 LANGUAGE > LC_ALL，因此必须同时处理两者，才能保证
+    下游对 stderr 文本的匹配在所有环境中一致。
     """
-    env = {**os.environ, "LC_ALL": "C"}
+    env = {**os.environ, "LC_ALL": "C", "LANGUAGE": ""}
     return subprocess.run(
         ["git", *_git_cwd_args(), *args],
         capture_output=True,

--- a/discovery/generate_conf.py
+++ b/discovery/generate_conf.py
@@ -102,11 +102,17 @@ def _git_cwd_args() -> list:
 
 
 def _git_run(args: list, **kwargs) -> subprocess.CompletedProcess:
-    """在仓库根目录运行 git 命令，返回 CompletedProcess（含 stdout/stderr）。"""
+    """在仓库根目录运行 git 命令，返回 CompletedProcess（含 stdout/stderr）。
+
+    固定 LC_ALL=C，避免 git 的 fatal 消息随 locale 本地化，确保下游对
+    stderr 文本的匹配在所有环境中一致。
+    """
+    env = {**os.environ, "LC_ALL": "C"}
     return subprocess.run(
         ["git", *_git_cwd_args(), *args],
         capture_output=True,
         text=True,
+        env=env,
         **kwargs,
     )
 

--- a/tests/test_discovery_generate_conf.py
+++ b/tests/test_discovery_generate_conf.py
@@ -232,7 +232,117 @@ def test_inherit_from_branch_dry_run_does_not_write(tmp_path: Path, monkeypatch:
 
 
 # ---------------------------------------------------------------------------
-# 4. CLI argument wiring
+# 4. Resolving refs with origin remote (CI path) and fetch failures
+# ---------------------------------------------------------------------------
+
+
+def _add_origin_remote(repo: Path, bare_remote: Path):
+    """把 bare_remote 作为 origin 远程配置到 repo。"""
+    subprocess.run(
+        ["git", "remote", "add", "origin", str(bare_remote)],
+        cwd=repo, check=True, capture_output=True,
+    )
+
+
+def test_resolve_inherit_refs_prefers_local_branch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """本地分支存在时，不尝试 fetch origin，直接返回本地引用。"""
+    repo = _init_git_repo(tmp_path)
+    conf_dir = repo / "conf"
+    conf_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(generate_conf, "CONF_DIR", conf_dir)
+
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "-b", "auto-discover-confs"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "main"], cwd=repo, check=True, capture_output=True)
+
+    refs = generate_conf._resolve_inherit_refs("auto-discover-confs")
+    assert refs == ["auto-discover-confs"]
+
+
+def test_resolve_inherit_refs_fetches_from_origin_in_ci(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """模拟 CI 环境：本地无目标分支，但 origin 远程有，应 fetch 后返回 origin/<branch>。"""
+    remote = tmp_path / "remote.git"
+    repo = tmp_path / "repo"
+    remote.mkdir()
+    repo.mkdir()
+
+    # 初始化 bare remote
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+
+    # 在 repo 中创建 main + auto-discover-confs，并推送到 origin
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "-b", "main"], cwd=repo, check=True, capture_output=True)
+
+    conf_dir = repo / "conf"
+    monkeypatch.setattr(generate_conf, "CONF_DIR", conf_dir)
+    _write_conf(conf_dir, "dblp_conf.json", [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+    ])
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "main"], cwd=repo, check=True, capture_output=True)
+
+    subprocess.run(["git", "checkout", "-b", "auto-discover-confs"], cwd=repo, check=True, capture_output=True)
+    _write_conf(conf_dir, "dblp_conf.json", [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+        {"name": "ICDE2026", "url": "https://dblp.org/db/conf/icde/icde2026.html"},
+    ])
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "discover"], cwd=repo, check=True, capture_output=True)
+
+    subprocess.run(["git", "checkout", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "push", "-u", str(remote), "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "push", "-u", str(remote), "auto-discover-confs"], cwd=repo, check=True, capture_output=True)
+
+    # 删除本地 auto-discover-confs，模拟 CI fresh checkout
+    subprocess.run(["git", "branch", "-D", "auto-discover-confs"], cwd=repo, check=True, capture_output=True)
+
+    _add_origin_remote(repo, remote)
+
+    refs = generate_conf._resolve_inherit_refs("auto-discover-confs")
+    assert "origin/auto-discover-confs" in refs
+
+    # 验证从 origin 读取并合并成功
+    generate_conf.inherit_from_branch("auto-discover-confs")
+    merged = _read_conf(conf_dir, "dblp_conf.json")
+    assert any(item["name"] == "ICDE2026" for item in merged)
+
+
+def test_resolve_inherit_refs_fails_fast_on_fetch_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """origin 存在但 fetch 失败时，应抛出 InheritBranchError 而不是静默降级。"""
+    repo = _init_git_repo(tmp_path)
+    conf_dir = repo / "conf"
+    conf_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(generate_conf, "CONF_DIR", conf_dir)
+
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "init"], cwd=repo, check=True, capture_output=True)
+
+    # 配置一个指向不存在路径的 origin，使 fetch 必然失败
+    fake_remote = tmp_path / "nonexistent-remote.git"
+    _add_origin_remote(repo, fake_remote)
+
+    with pytest.raises(generate_conf.InheritBranchError):
+        generate_conf._resolve_inherit_refs("auto-discover-confs")
+
+
+def test_main_exits_on_inherit_branch_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """main() 入口在遇到 InheritBranchError 时应以非零码退出。"""
+    repo = _init_git_repo(tmp_path)
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "init"], cwd=repo, check=True, capture_output=True)
+    fake_remote = tmp_path / "nonexistent-remote.git"
+    _add_origin_remote(repo, fake_remote)
+
+    monkeypatch.setattr(generate_conf, "CONF_DIR", repo / "conf")
+
+    with pytest.raises(SystemExit) as exc_info:
+        generate_conf.main(["--inherit-branch", "auto-discover-confs"])
+
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. CLI argument wiring
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_discovery_generate_conf.py
+++ b/tests/test_discovery_generate_conf.py
@@ -346,6 +346,62 @@ def test_resolve_inherit_refs_degrades_when_remote_ref_missing(tmp_path: Path, m
     ]
 
 
+def test_git_run_forces_c_locale(monkeypatch: pytest.MonkeyPatch):
+    """_git_run 必须为 git 子进程显式设置 LC_ALL=C，避免 stderr 被本地化。"""
+    captured = {}
+    original_run = subprocess.run
+
+    def fake_run(*args, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    generate_conf._git_run(["status"])
+
+    assert captured.get("env", {}).get("LC_ALL") == "C"
+
+
+def test_resolve_inherit_refs_degrades_under_non_english_locale(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """父进程 locale 非英文时，远程无该分支仍应优雅降级（git 子进程 stderr 被固定为英文）。"""
+    # 强制父进程使用非英文 locale（若系统不支持，git 仍会回退英文；关键是
+    # 我们显式设置 LC_ALL=C 的子进程不应受父进程 locale 影响）
+    monkeypatch.setenv("LC_ALL", "zh_CN.UTF-8")
+    monkeypatch.setenv("LANG", "zh_CN.UTF-8")
+
+    remote = tmp_path / "remote.git"
+    repo = tmp_path / "repo"
+    remote.mkdir()
+    repo.mkdir()
+
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "-b", "main"], cwd=repo, check=True, capture_output=True)
+
+    conf_dir = repo / "conf"
+    monkeypatch.setattr(generate_conf, "CONF_DIR", conf_dir)
+    conf_dir.mkdir(parents=True, exist_ok=True)
+    _write_conf(conf_dir, "dblp_conf.json", [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+    ])
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "push", "-u", str(remote), "main"], cwd=repo, check=True, capture_output=True)
+
+    _add_origin_remote(repo, remote)
+
+    refs = generate_conf._resolve_inherit_refs("auto-discover-confs")
+    assert refs == ["origin/auto-discover-confs", "auto-discover-confs"]
+
+    generate_conf.inherit_from_branch("auto-discover-confs")
+    assert _read_conf(conf_dir, "dblp_conf.json") == [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+    ]
+
+
 def test_resolve_inherit_refs_fails_fast_on_fetch_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """origin 存在但 fetch 失败时，应抛出 InheritBranchError 而不是静默降级。"""
     repo = _init_git_repo(tmp_path)

--- a/tests/test_discovery_generate_conf.py
+++ b/tests/test_discovery_generate_conf.py
@@ -360,14 +360,16 @@ def test_git_run_forces_c_locale(monkeypatch: pytest.MonkeyPatch):
     generate_conf._git_run(["status"])
 
     assert captured.get("env", {}).get("LC_ALL") == "C"
+    assert captured.get("env", {}).get("LANGUAGE") == ""
 
 
 def test_resolve_inherit_refs_degrades_under_non_english_locale(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """父进程 locale 非英文时，远程无该分支仍应优雅降级（git 子进程 stderr 被固定为英文）。"""
     # 强制父进程使用非英文 locale（若系统不支持，git 仍会回退英文；关键是
-    # 我们显式设置 LC_ALL=C 的子进程不应受父进程 locale 影响）
+    # 我们显式设置 LC_ALL=C / LANGUAGE="" 的子进程不应受父进程 locale 影响）
     monkeypatch.setenv("LC_ALL", "zh_CN.UTF-8")
     monkeypatch.setenv("LANG", "zh_CN.UTF-8")
+    monkeypatch.setenv("LANGUAGE", "zh_CN.UTF-8")
 
     remote = tmp_path / "remote.git"
     repo = tmp_path / "repo"

--- a/tests/test_discovery_generate_conf.py
+++ b/tests/test_discovery_generate_conf.py
@@ -309,6 +309,43 @@ def test_resolve_inherit_refs_fetches_from_origin_in_ci(tmp_path: Path, monkeypa
     assert any(item["name"] == "ICDE2026" for item in merged)
 
 
+def test_resolve_inherit_refs_degrades_when_remote_ref_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """origin 存在但远程无该分支时，应优雅降级而不是抛异常。"""
+    remote = tmp_path / "remote.git"
+    repo = tmp_path / "repo"
+    remote.mkdir()
+    repo.mkdir()
+
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "-b", "main"], cwd=repo, check=True, capture_output=True)
+
+    conf_dir = repo / "conf"
+    monkeypatch.setattr(generate_conf, "CONF_DIR", conf_dir)
+    conf_dir.mkdir(parents=True, exist_ok=True)
+    _write_conf(conf_dir, "dblp_conf.json", [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+    ])
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "push", "-u", str(remote), "main"], cwd=repo, check=True, capture_output=True)
+
+    _add_origin_remote(repo, remote)
+
+    # 远程只有 main，没有 auto-discover-confs；不应抛异常
+    refs = generate_conf._resolve_inherit_refs("auto-discover-confs")
+    assert refs == ["origin/auto-discover-confs", "auto-discover-confs"]
+
+    # 继承流程也应安全跳过，不破坏现有文件
+    generate_conf.inherit_from_branch("auto-discover-confs")
+    assert _read_conf(conf_dir, "dblp_conf.json") == [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+    ]
+
+
 def test_resolve_inherit_refs_fails_fast_on_fetch_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """origin 存在但 fetch 失败时，应抛出 InheritBranchError 而不是静默降级。"""
     repo = _init_git_repo(tmp_path)

--- a/tests/test_discovery_generate_conf.py
+++ b/tests/test_discovery_generate_conf.py
@@ -1,0 +1,258 @@
+"""Tests for `discovery/generate_conf.py` — merge/insertion logic and the
+`--inherit-branch` machinery that prevents unmerged auto-discoveries from
+being overwritten by the next workflow run.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import List, Dict, Any
+
+import pytest
+
+from discovery import generate_conf
+
+
+def _write_conf(conf_dir: Path, filename: str, data: List[Dict[str, Any]]):
+    path = conf_dir / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=4), encoding="utf-8")
+
+
+def _read_conf(conf_dir: Path, filename: str) -> List[Dict[str, Any]]:
+    path = conf_dir / filename
+    if not path.exists():
+        return []
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# 1. merge_conf / insertion ordering
+# ---------------------------------------------------------------------------
+
+
+def test_merge_conf_dedupes_by_url():
+    existing = [
+        {"name": "ACL2024", "url": "https://aclanthology.org/events/acl-2024/"},
+    ]
+    new = [
+        {"name": "ACL2024", "url": "https://aclanthology.org/events/acl-2024/"},
+        {"name": "ACL2025", "url": "https://aclanthology.org/events/acl-2025/"},
+    ]
+    merged = generate_conf.merge_conf(existing, new)
+    assert len(merged) == 2
+    assert merged[0]["name"] == "ACL2024"
+    assert merged[1]["name"] == "ACL2025"
+
+
+def test_merge_conf_inserts_after_same_name():
+    existing = [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+        {"name": "DAC2000", "url": "https://dblp.org/db/conf/dac/dac2000.html"},
+    ]
+    new = [
+        {"name": "ICDE2026", "url": "https://dblp.org/db/conf/icde/icde2026.html"},
+    ]
+    merged = generate_conf.merge_conf(existing, new)
+    # ICDE2026 should be inserted right after ICDE2018.
+    assert [m["name"] for m in merged] == ["ICDE2018", "ICDE2026", "DAC2000"]
+
+
+def test_merge_conf_orders_by_year_within_same_prefix():
+    existing = [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+    ]
+    new = [
+        {"name": "ICDE2020", "url": "https://dblp.org/db/conf/icde/icde2020.html"},
+        {"name": "ICDE2019", "url": "https://dblp.org/db/conf/icde/icde2019.html"},
+    ]
+    merged = generate_conf.merge_conf(existing, new)
+    assert [m["name"] for m in merged] == ["ICDE2018", "ICDE2019", "ICDE2020"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Loading conf from a git ref
+# ---------------------------------------------------------------------------
+
+
+def _init_git_repo(tmp_path: Path) -> Path:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+    # 显式创建 main 分支，避免不同 git 默认分支不一致导致测试歧义
+    subprocess.run(
+        ["git", "checkout", "-b", "main"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+    return tmp_path
+
+
+def test_load_conf_from_ref_reads_branch_content(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    repo = _init_git_repo(tmp_path)
+    conf_dir = repo / "conf"
+    monkeypatch.setattr(generate_conf, "CONF_DIR", conf_dir)
+
+    _write_conf(conf_dir, "dblp_conf.json", [
+        {"name": "ICDE2026", "url": "https://dblp.org/db/conf/icde/icde2026.html"},
+    ])
+
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "-b", "auto-discover-confs"], cwd=repo, check=True, capture_output=True)
+
+    data = generate_conf._load_conf_from_ref("auto-discover-confs", "dblp_conf.json")
+    assert data == [
+        {"name": "ICDE2026", "url": "https://dblp.org/db/conf/icde/icde2026.html"},
+    ]
+
+
+def test_load_conf_from_ref_returns_empty_when_ref_missing(tmp_path: Path):
+    repo = _init_git_repo(tmp_path)
+    # No conf file committed, no branch.
+    assert generate_conf._load_conf_from_ref("nonexistent-branch", "dblp_conf.json") == []
+
+
+# ---------------------------------------------------------------------------
+# 3. inherit_from_branch merges unmerged discoveries into the working tree
+# ---------------------------------------------------------------------------
+
+
+def test_inherit_from_branch_merges_unmerged_entries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    repo = _init_git_repo(tmp_path)
+    conf_dir = repo / "conf"
+    monkeypatch.setattr(generate_conf, "CONF_DIR", conf_dir)
+
+    # main 状态
+    _write_conf(conf_dir, "dblp_conf.json", [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+    ])
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "main"], cwd=repo, check=True, capture_output=True)
+
+    # 模拟 auto-discover-confs 分支：包含未合并的 ICDE2026
+    subprocess.run(["git", "checkout", "-b", "auto-discover-confs"], cwd=repo, check=True, capture_output=True)
+    _write_conf(conf_dir, "dblp_conf.json", [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+        {"name": "ICDE2026", "url": "https://dblp.org/db/conf/icde/icde2026.html"},
+    ])
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "discover ICDE2026"], cwd=repo, check=True, capture_output=True)
+
+    # 切回 main（工作区会被 checkout 重置为 main 状态）
+    subprocess.run(["git", "checkout", "main"], cwd=repo, check=True, capture_output=True)
+    assert _read_conf(conf_dir, "dblp_conf.json") == [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+    ]
+
+    # 继承未合并分支
+    generate_conf.inherit_from_branch("auto-discover-confs")
+
+    merged = _read_conf(conf_dir, "dblp_conf.json")
+    assert len(merged) == 2
+    assert merged[1]["name"] == "ICDE2026"
+
+
+def test_inherit_from_branch_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    repo = _init_git_repo(tmp_path)
+    conf_dir = repo / "conf"
+    monkeypatch.setattr(generate_conf, "CONF_DIR", conf_dir)
+
+    _write_conf(conf_dir, "dblp_conf.json", [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+        {"name": "ICDE2026", "url": "https://dblp.org/db/conf/icde/icde2026.html"},
+    ])
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "main already has it"], cwd=repo, check=True, capture_output=True)
+
+    subprocess.run(["git", "checkout", "-b", "auto-discover-confs"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "empty"], cwd=repo, check=True, capture_output=True)
+
+    subprocess.run(["git", "checkout", "main"], cwd=repo, check=True, capture_output=True)
+
+    generate_conf.inherit_from_branch("auto-discover-confs")
+    # Nothing new to inherit; file should stay identical.
+    merged = _read_conf(conf_dir, "dblp_conf.json")
+    assert len(merged) == 2
+
+
+def test_inherit_from_branch_silently_skips_missing_branch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    repo = _init_git_repo(tmp_path)
+    conf_dir = repo / "conf"
+    monkeypatch.setattr(generate_conf, "CONF_DIR", conf_dir)
+
+    _write_conf(conf_dir, "dblp_conf.json", [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+    ])
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "main"], cwd=repo, check=True, capture_output=True)
+
+    # 不抛异常、不破坏现有文件
+    generate_conf.inherit_from_branch("origin/does-not-exist")
+    assert _read_conf(conf_dir, "dblp_conf.json") == [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+    ]
+
+
+def test_inherit_from_branch_dry_run_does_not_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    repo = _init_git_repo(tmp_path)
+    conf_dir = repo / "conf"
+    monkeypatch.setattr(generate_conf, "CONF_DIR", conf_dir)
+
+    # main 状态
+    _write_conf(conf_dir, "dblp_conf.json", [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+    ])
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "main"], cwd=repo, check=True, capture_output=True)
+
+    # 模拟未合并分支
+    subprocess.run(["git", "checkout", "-b", "auto-discover-confs"], cwd=repo, check=True, capture_output=True)
+    _write_conf(conf_dir, "dblp_conf.json", [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+        {"name": "ICDE2026", "url": "https://dblp.org/db/conf/icde/icde2026.html"},
+    ])
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "discover"], cwd=repo, check=True, capture_output=True)
+
+    subprocess.run(["git", "checkout", "main"], cwd=repo, check=True, capture_output=True)
+
+    # dry-run 模式下不应写入文件
+    generate_conf.inherit_from_branch("auto-discover-confs", dry_run=True)
+    assert _read_conf(conf_dir, "dblp_conf.json") == [
+        {"name": "ICDE2018", "url": "https://dblp.org/db/conf/icde/icde2018.html"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 4. CLI argument wiring
+# ---------------------------------------------------------------------------
+
+
+def test_cli_parses_inherit_branch():
+    """命令行能正确解析 --inherit-branch。"""
+    parser = generate_conf._build_parser()
+    args = parser.parse_args([
+        "--start-year", "2024",
+        "--end-year", "2025",
+        "--dry-run",
+        "--inherit-branch", "auto-discover-confs",
+    ])
+    assert args.start_year == 2024
+    assert args.end_year == 2025
+    assert args.dry_run is True
+    assert getattr(args, "inherit_branch") == "auto-discover-confs"
+
+
+def test_cli_inherit_branch_defaults_to_none():
+    """--inherit-branch 不传时默认值为 None。"""
+    parser = generate_conf._build_parser()
+    args = parser.parse_args([])
+    assert getattr(args, "inherit_branch") is None


### PR DESCRIPTION
… branch

Previously, the discover_and_update workflow always checked out main and let peter-evans/create-pull-request reset auto-discover-confs. Any unmerged conference discoveries on that branch were overwritten.

This change adds --inherit-branch to discovery/generate_conf.py. Before discovering new conferences, it reads conf/*.json from the specified branch/ref, merges them into the working tree using the existing URL-based merge_conf() logic, and then runs discovery. The workflow now passes --inherit-branch auto-discover-confs.

Also adds concurrency to the workflow so only one discover instance runs at a time, preventing race conditions.

新增测试覆盖继承、去重、dry-run 以及 CLI 参数解析。